### PR TITLE
Refactor action base name

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/RK-ResearchSuite-Android.iml" filepath="$PROJECT_DIR$/RK-ResearchSuite-Android.iml" />
+      <module fileurl="file://$PROJECT_DIR$/ResearchSuite-Android.iml" filepath="$PROJECT_DIR$/ResearchSuite-Android.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/data/data.iml" filepath="$PROJECT_DIR$/data/data.iml" />
       <module fileurl="file://$PROJECT_DIR$/domain/domain.iml" filepath="$PROJECT_DIR$/domain/domain.iml" />

--- a/app/src/main/assets/task/foo.json
+++ b/app/src/main/assets/task/foo.json
@@ -3,7 +3,7 @@
   "asyncActions": [],
   "actions": {
     "cancel": {
-      "type": "base",
+      "type": "default",
       "iconName": "closeActivity"
     }
   },
@@ -21,7 +21,7 @@
       "image": "before",
       "actions": {
         "goForward": {
-          "type": "base",
+          "type": "default",
           "buttonTitle": "Go, Dogs!"
         }
       }
@@ -115,7 +115,7 @@
       },
       "actions": {
         "goForward": {
-          "type": "base",
+          "type": "default",
           "buttonTitle": "Start"
         }
       }

--- a/app/src/main/assets/task/instructionStepTest.json
+++ b/app/src/main/assets/task/instructionStepTest.json
@@ -6,7 +6,7 @@
   "detail": "On this screen you should see an image below the text with a picture of a phone in a pocket. The next step after this one is an active step. When it starts, you should hear voice commands.",
   "actions": {
     "goForward": {
-      "type": "base",
+      "type": "default",
       "buttonTitle": "Start"
     }
   }

--- a/app/src/main/assets/task/transformer/TremorSectionStep.json
+++ b/app/src/main/assets/task/transformer/TremorSectionStep.json
@@ -25,7 +25,7 @@
       },
       "actions": {
         "goForward": {
-          "type": "base",
+          "type": "default",
           "buttonTitle": "Hold phone"
         }
       }

--- a/domain/src/main/java/org/sagebionetworks/research/domain/result/implementations/ResultBase.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/result/implementations/ResultBase.java
@@ -62,7 +62,7 @@ public class ResultBase extends ObjectHelper implements Result {
 
     /**
      * Constructor for subclasses to use to allow them to have the correct type. If the given type is null the type
-     * for this result is assumed to be ResultType.BASE.
+     * for this result is assumed to be ResultType.DEFAULT.
      *
      * @param identifier
      *         The identifier of the result type.

--- a/domain/src/main/java/org/sagebionetworks/research/domain/result/implementations/ResultBase.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/result/implementations/ResultBase.java
@@ -62,7 +62,7 @@ public class ResultBase extends ObjectHelper implements Result {
 
     /**
      * Constructor for subclasses to use to allow them to have the correct type. If the given type is null the type
-     * for this result is assumed to be ResultType.DEFAULT.
+     * for this result is assumed to be ResultType.BASE.
      *
      * @param identifier
      *         The identifier of the result type.

--- a/domain/src/main/java/org/sagebionetworks/research/domain/step/ui/action/ActionDeserializationType.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/step/ui/action/ActionDeserializationType.java
@@ -34,9 +34,9 @@ package org.sagebionetworks.research.domain.step.ui.action;
 
 import android.support.annotation.StringDef;
 
-@StringDef({ActionDeserializationType.BASE, ActionDeserializationType.REMINDER, ActionDeserializationType.SKIP})
+@StringDef({ActionDeserializationType.DEFAULT, ActionDeserializationType.REMINDER, ActionDeserializationType.SKIP})
 public @interface ActionDeserializationType {
-    String BASE = "Base";
+    String DEFAULT = "default";
     String REMINDER = "reminder";
     String SKIP = "skip";
 }

--- a/domain/src/main/java/org/sagebionetworks/research/domain/step/ui/action/implementations/ActionBase.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/step/ui/action/implementations/ActionBase.java
@@ -52,7 +52,7 @@ public abstract class ActionBase implements Action {
         public abstract Builder setButtonTitle(@Nullable String buttonTitle);
     }
 
-    public static final String TYPE_KEY = ActionDeserializationType.BASE;
+    public static final String TYPE_KEY = ActionDeserializationType.DEFAULT;
 
     public static Builder builder() {
         return new AutoValue_ActionBase.Builder();


### PR DESCRIPTION
The default action was being deserialized with the name "base" this was changed to "default" to match iOS.