### PR TITLE
null sharedPrefs

### DIFF
--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/perform_task/PerformTaskViewModel.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/perform_task/PerformTaskViewModel.java
@@ -413,12 +413,14 @@ public class PerformTaskViewModel extends AndroidViewModel {
                 compositeDisposable.add(
                         taskResultManagerConnectionSingle
                                 .subscribe((resultManagerConnection) -> {
-                                    resultManagerConnection.addAsyncActionResult(Maybe.fromCallable(
-                                            () -> new AnswerResultBase<>(LAST_RUN_RESULT_ID, Instant.now(), Instant.now(),
-                                                    sharedPrefsArgs.lastRun, AnswerResultType.DATE)));
-                                    resultManagerConnection.addAsyncActionResult(Maybe.fromCallable(
-                                            () -> new AnswerResultBase<>(RUN_COUNT_RESULT_ID, Instant.now(), Instant.now(),
-                                                    sharedPrefsArgs.runCount, AnswerResultType.INTEGER)));
+                                    if (sharedPrefsArgs != null) {
+                                        resultManagerConnection.addAsyncActionResult(Maybe.fromCallable(
+                                                () -> new AnswerResultBase<>(LAST_RUN_RESULT_ID, Instant.now(), Instant.now(),
+                                                        sharedPrefsArgs.lastRun, AnswerResultType.DATE)));
+                                        resultManagerConnection.addAsyncActionResult(Maybe.fromCallable(
+                                                () -> new AnswerResultBase<>(RUN_COUNT_RESULT_ID, Instant.now(), Instant.now(),
+                                                        sharedPrefsArgs.runCount, AnswerResultType.INTEGER)));
+                                    }
                                     goForward();
                                 }, t -> taskInitFail(t)));
 


### PR DESCRIPTION
Fixed bug where an exception here would cause the live data to be disconnected from the task result service.

I can't really say what other affects this will have on a task that needs the last run uuid or run count to operate fine.  It would depend if they safely null-checked in the code or not.