### PR TITLE
AA-355

### DIFF
--- a/app/src/main/java/org/sagebionetworks/research/app/InstructionStep.java
+++ b/app/src/main/java/org/sagebionetworks/research/app/InstructionStep.java
@@ -83,9 +83,6 @@ public abstract class InstructionStep implements ActiveUIStep {
         public abstract Builder setDuration(@Nullable Double duration);
 
         @NonNull
-        public abstract Builder setIsFirstRunOnly(boolean isFirstRunOnly);
-
-        @NonNull
         public abstract Builder setFootnote(@Nullable String footnote);
 
         @NonNull
@@ -134,8 +131,6 @@ public abstract class InstructionStep implements ActiveUIStep {
     public final String getType() {
         return StepType.INSTRUCTION;
     }
-
-    abstract boolean isFirstRunOnly();
 
     @NonNull
     abstract Builder toBuilder();

--- a/app/src/main/java/org/sagebionetworks/research/app/InstructionStep.java
+++ b/app/src/main/java/org/sagebionetworks/research/app/InstructionStep.java
@@ -83,7 +83,7 @@ public abstract class InstructionStep implements ActiveUIStep {
         public abstract Builder setDuration(@Nullable Double duration);
 
         @NonNull
-        public abstract Builder setFirstRunOnly(boolean firstRunOnly);
+        public abstract Builder setIsFirstRunOnly(boolean isFirstRunOnly);
 
         @NonNull
         public abstract Builder setFootnote(@Nullable String footnote);

--- a/data/src/main/java/org/sagebionetworks/research/data/ResourceTaskRepository.java
+++ b/data/src/main/java/org/sagebionetworks/research/data/ResourceTaskRepository.java
@@ -32,6 +32,8 @@
 
 package org.sagebionetworks.research.data;
 
+import static org.sagebionetworks.research.domain.task.navigation.TreeNavigator.SECTION_STEP_PREFIX_SEPARATOR;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import android.content.Context;
@@ -223,7 +225,8 @@ public class ResourceTaskRepository implements TaskRepository {
             ImmutableList<Step> steps = section.getSteps();
             ImmutableList.Builder<Step> builder = new ImmutableList.Builder<>();
             for (Step innerStep : steps) {
-                builder.add(resolveTransformers(innerStep, prefix + section.getIdentifier() + "_"));
+                builder.add(resolveTransformers(innerStep,
+                        prefix + section.getIdentifier() + SECTION_STEP_PREFIX_SEPARATOR));
             }
 
             return section.copyWithSteps(builder.build());
@@ -272,7 +275,8 @@ public class ResourceTaskRepository implements TaskRepository {
                     }
                 }
 
-                copy = copy.copyWithIdentifier(step.getIdentifier() + "_" + copy.getIdentifier());
+                copy = copy.copyWithIdentifier(
+                        step.getIdentifier() + SECTION_STEP_PREFIX_SEPARATOR + copy.getIdentifier());
                 accumlator.add(copy);
             }
         }

--- a/domain/src/main/java/org/sagebionetworks/research/domain/impl/ActionAutoValueModule.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/impl/ActionAutoValueModule.java
@@ -41,7 +41,7 @@ import org.sagebionetworks.research.domain.inject.GsonModule;
 import org.sagebionetworks.research.domain.inject.GsonModule.ClassKey;
 import org.sagebionetworks.research.domain.step.ui.action.Action;
 import org.sagebionetworks.research.domain.step.ui.action.ReminderAction;
-import org.sagebionetworks.research.domain.step.ui.action.SkipToStepAction;
+import org.sagebionetworks.research.domain.step.ui.action.SkipToAction;
 
 import dagger.Module;
 import dagger.Provides;
@@ -79,15 +79,15 @@ public class ActionAutoValueModule {
 
     @Provides
     @IntoMap
-    @ClassKey(SkipToStepAction.class)
+    @ClassKey(SkipToAction.class)
     static JsonDeserializer<?> provideSkipToStepActionDeserializer() {
-        return createPassThroughDeserializer(SkipToStepActionImpl.class);
+        return createPassThroughDeserializer(SkipToActionImpl.class);
     }
 
     @Provides
     @IntoMap
-    @ActionKey(SkipToStepAction.class)
+    @ActionKey(SkipToAction.class)
     static String provideSkipToStepActionTypeKey() {
-        return SkipToStepActionImpl.TYPE_KEY;
+        return SkipToActionImpl.TYPE_KEY;
     }
 }

--- a/domain/src/main/java/org/sagebionetworks/research/domain/impl/SkipToActionImpl.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/impl/SkipToActionImpl.java
@@ -30,25 +30,43 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.sagebionetworks.research.presentation.recorder.sensor;
+package org.sagebionetworks.research.domain.impl;
 
-import android.support.annotation.NonNull;
+import com.google.auto.value.AutoValue;
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
 
-import org.sagebionetworks.research.presentation.recorder.RecorderConfigPresentation;
-import org.sagebionetworks.research.presentation.recorder.RestartableRecorderConfiguration;
-import org.sagebionetworks.research.presentation.recorder.reactive.source.SensorSourceFactory.SensorConfig;
+import org.sagebionetworks.research.domain.step.ui.action.ActionDeserializationType;
+import org.sagebionetworks.research.domain.step.ui.action.SkipToAction;
 
-import java.util.Set;
+@AutoValue
+abstract class SkipToActionImpl implements SkipToAction {
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract SkipToActionImpl build();
 
-/**
- * Recorder configuration for sensors available through android.hardware.SensorManager.
- */
-public interface SensorRecorderConfigPresentation extends RestartableRecorderConfiguration {
-    /**
-     * Returns the set of recorder types that the motion recorder should measure.
-     *
-     * @return the set of recorder types that the motion recorder should measure.
-     */
-    @NonNull
-    Set<SensorConfig> getSensorConfigs();
+        public abstract Builder setButtonIconName(String buttonIconName);
+
+        public abstract Builder setButtonTitle(String buttonTitle);
+
+        public abstract Builder setSkipToIdentifier(String skipToIdentifier);
+    }
+
+    public static final String TYPE_KEY = ActionDeserializationType.SKIP;
+
+    public static Builder builder() {
+        return new AutoValue_SkipToActionImpl.Builder();
+    }
+
+    public static TypeAdapter<SkipToActionImpl> typeAdapter(Gson gson) {
+        return new AutoValue_SkipToActionImpl.GsonTypeAdapter(gson);
+    }
+
+    @Override
+    @ActionDeserializationType
+    public String getType() {
+        return TYPE_KEY;
+    }
+
+    public abstract Builder toBuilder();
 }

--- a/domain/src/main/java/org/sagebionetworks/research/domain/inject/ActionModule.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/inject/ActionModule.java
@@ -35,10 +35,6 @@ package org.sagebionetworks.research.domain.inject;
 import org.sagebionetworks.research.domain.RuntimeTypeAdapterFactory;
 import org.sagebionetworks.research.domain.step.ui.action.Action;
 import org.sagebionetworks.research.domain.impl.ActionAutoValueModule;
-import org.sagebionetworks.research.domain.step.ui.action.ReminderAction;
-import org.sagebionetworks.research.domain.step.ui.action.SkipToStepAction;
-import org.sagebionetworks.research.domain.step.ui.action.Action;
-import org.sagebionetworks.research.domain.impl.ActionAutoValueModule;
 
 import java.util.Map;
 import java.util.Map.Entry;

--- a/domain/src/main/java/org/sagebionetworks/research/domain/result/implementations/NavigationResultBase.kt
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/result/implementations/NavigationResultBase.kt
@@ -62,7 +62,6 @@ class NavigationResultBase(
 /**
  * NavigationAnswerResultBase is a simple encapsulation of an AnswerResult that can control navigation when
  * the next step is determined by a StrategyBasedNavigator.
- * the next step is determined by a StrategyBasedNavigator.
  * @param identifier the step identifier to be assigned to the result.
  * @param startTime The start Instant of this result.
  * @param endTime The end Instant of this result.

--- a/domain/src/main/java/org/sagebionetworks/research/domain/result/implementations/NavigationResultBase.kt
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/result/implementations/NavigationResultBase.kt
@@ -1,0 +1,78 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright 2018  Sage Bionetworks. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission. No license is granted to the trademarks of
+ * the copyright holders even if such marks are included in this software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.sagebionetworks.research.domain.result.implementations
+
+import org.sagebionetworks.research.domain.result.AnswerResultType
+import org.sagebionetworks.research.domain.result.interfaces.AnswerResult
+import org.sagebionetworks.research.domain.result.interfaces.NavigationResult
+import org.sagebionetworks.research.domain.result.interfaces.Result
+import org.threeten.bp.Instant
+
+/**
+ * NavigationResultDelegation can be used to attached navigation result functionality to any other result type,
+ * without the need for a complex class type hierarchy.
+ * For an example see NavigationResultBase or NavigationAnswerResultBase.
+ */
+class NavigationResultDelegation(override val skipToIdentifier: String? = null): NavigationResult
+
+/**
+ * NavigationResultBase is a simple encapsulation of a result that can control navigation when
+ * the next step is determined by a StrategyBasedNavigator.
+ * @param identifier the step identifier to be assigned to the result.
+ * @param startTime The start Instant of this result.
+ * @param endTime The end Instant of this result.
+ * @param skipToIdentifier The identifier of the step to go to next.
+ *                         If null, next will be use default stradegy behavior.
+ */
+class NavigationResultBase(
+        identifier: String, startTime: Instant, endTime: Instant, skipToIdentifier: String? = null):
+            Result by ResultBase(identifier, startTime, endTime),
+            NavigationResult by NavigationResultDelegation(skipToIdentifier)
+
+/**
+ * NavigationAnswerResultBase is a simple encapsulation of an AnswerResult that can control navigation when
+ * the next step is determined by a StrategyBasedNavigator.
+ * the next step is determined by a StrategyBasedNavigator.
+ * @param identifier the step identifier to be assigned to the result.
+ * @param startTime The start Instant of this result.
+ * @param endTime The end Instant of this result.
+ * @param answer of the result, can be any generic type compatible with @AnswerResultType
+ * @param answerResultType of the result
+ * @param skipToIdentifier The identifier of the step to go to next.
+ *                         If null, next will be use default stradegy behavior.
+ */
+class NavigationAnswerResultBase<T>(
+        identifier: String, startTime: Instant, endTime: Instant,
+        answer: T?, @AnswerResultType answerResultType: String, skipToIdentifier: String? = null):
+            AnswerResult<T> by AnswerResultBase<T>(identifier, startTime, endTime, answer, answerResultType),
+            NavigationResult by NavigationResultDelegation(skipToIdentifier)

--- a/domain/src/main/java/org/sagebionetworks/research/domain/result/implementations/TaskResultBase.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/result/implementations/TaskResultBase.java
@@ -191,6 +191,28 @@ public class TaskResultBase extends ResultBase implements TaskResult {
         return new TaskResultBase(this, newData);
     }
 
+    @Nullable
+    @Override
+    public TaskResult removeAsyncResult(final Result result) {
+        List<Result> asyncResults = new ArrayList<>(this.getAsyncResults());
+        Iterator<Result> iterator = asyncResults.iterator();
+        boolean foundResult = false;
+        while (iterator.hasNext()) {
+            Result stepResult = iterator.next();
+            if (!foundResult && stepResult.getIdentifier().equals(result.getIdentifier())) {
+                foundResult = true;
+            }
+
+            if (foundResult) {
+                iterator.remove();
+            }
+        }
+
+        TaskResultData newData = TaskResultData.create(
+                getTaskUUID(), getSchemaInfo(), getStepHistory(), asyncResults);
+        return new TaskResultBase(this, newData);
+    }
+
     @Override
     @NonNull
     public List<Result> getResultsMatchingRegex(@RegEx String regex) {

--- a/domain/src/main/java/org/sagebionetworks/research/domain/result/interfaces/NavigationResult.kt
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/result/interfaces/NavigationResult.kt
@@ -30,43 +30,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.sagebionetworks.research.domain.impl;
+package org.sagebionetworks.research.domain.result.interfaces
 
-import com.google.auto.value.AutoValue;
-import com.google.gson.Gson;
-import com.google.gson.TypeAdapter;
-
-import org.sagebionetworks.research.domain.step.ui.action.ActionDeserializationType;
-import org.sagebionetworks.research.domain.step.ui.action.SkipToStepAction;
-
-@AutoValue
-abstract class SkipToStepActionImpl implements SkipToStepAction {
-    @AutoValue.Builder
-    public abstract static class Builder {
-        public abstract SkipToStepActionImpl build();
-
-        public abstract Builder setButtonIconName(String buttonIconName);
-
-        public abstract Builder setButtonTitle(String buttonTitle);
-
-        public abstract Builder setSkipToStepIdentifier(String reminderIdentifier);
-    }
-
-    public static final String TYPE_KEY = ActionDeserializationType.SKIP;
-
-    public static Builder builder() {
-        return new AutoValue_SkipToStepActionImpl.Builder();
-    }
-
-    public static TypeAdapter<SkipToStepActionImpl> typeAdapter(Gson gson) {
-        return new AutoValue_SkipToStepActionImpl.GsonTypeAdapter(gson);
-    }
-
-    @Override
-    @ActionDeserializationType
-    public String getType() {
-        return TYPE_KEY;
-    }
-
-    public abstract Builder toBuilder();
+/**
+ * NavigationResult is used to communicate to a StrategyBasedNavigator to go directly to a step with
+ * identifier skipToIdentifier.
+ * This interface can be attached to any other result type using Kotlin object delegation.
+ * This allows for any sub-class of Result to attach Navigation functionality
+ * without extending directly from NavigationResult class type.
+ * See NavigationResultBase for examples.
+ */
+interface NavigationResult {
+    val skipToIdentifier: String?
 }
+

--- a/domain/src/main/java/org/sagebionetworks/research/domain/result/interfaces/TaskResult.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/result/interfaces/TaskResult.java
@@ -142,6 +142,16 @@ public interface TaskResult extends Result {
     TaskResult removeStepHistory(Result result);
 
     /**
+     * Returns a new TaskResult with the given result and all results after it removed from the async result list.
+     *
+     * @param result
+     *         The result to begin removing results at.
+     * @return a new TaskResult with the given result and all results after it removed from he async result list.
+     */
+    @Nullable
+    TaskResult removeAsyncResult(Result result);
+
+    /**
      * Returns a list of Results from this task result whose identifier match the given regex. If
      * no results match the empty list will be returned.
      * @param regex The regex to match in the results identifiers.

--- a/domain/src/main/java/org/sagebionetworks/research/domain/step/ui/action/SkipToAction.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/step/ui/action/SkipToAction.java
@@ -30,25 +30,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.sagebionetworks.research.presentation.recorder.sensor;
+package org.sagebionetworks.research.domain.step.ui.action;
 
-import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
-import org.sagebionetworks.research.presentation.recorder.RecorderConfigPresentation;
-import org.sagebionetworks.research.presentation.recorder.RestartableRecorderConfiguration;
-import org.sagebionetworks.research.presentation.recorder.reactive.source.SensorSourceFactory.SensorConfig;
-
-import java.util.Set;
-
-/**
- * Recorder configuration for sensors available through android.hardware.SensorManager.
- */
-public interface SensorRecorderConfigPresentation extends RestartableRecorderConfiguration {
+public interface SkipToAction extends Action {
     /**
-     * Returns the set of recorder types that the motion recorder should measure.
-     *
-     * @return the set of recorder types that the motion recorder should measure.
+     * @return the identifier of the step to skip to fro this action.
      */
-    @NonNull
-    Set<SensorConfig> getSensorConfigs();
+    @Nullable
+    String getSkipToIdentifier();
 }

--- a/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/NavDirection.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/NavDirection.java
@@ -30,25 +30,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.sagebionetworks.research.presentation.recorder.sensor;
+package org.sagebionetworks.research.domain.task.navigation;
 
-import android.support.annotation.NonNull;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
-import org.sagebionetworks.research.presentation.recorder.RecorderConfigPresentation;
-import org.sagebionetworks.research.presentation.recorder.RestartableRecorderConfiguration;
-import org.sagebionetworks.research.presentation.recorder.reactive.source.SensorSourceFactory.SensorConfig;
+import android.support.annotation.IntDef;
 
-import java.util.Set;
+import java.lang.annotation.Retention;
 
-/**
- * Recorder configuration for sensors available through android.hardware.SensorManager.
- */
-public interface SensorRecorderConfigPresentation extends RestartableRecorderConfiguration {
-    /**
-     * Returns the set of recorder types that the motion recorder should measure.
-     *
-     * @return the set of recorder types that the motion recorder should measure.
-     */
-    @NonNull
-    Set<SensorConfig> getSensorConfigs();
+@Retention(SOURCE)
+@IntDef({NavDirection.SHIFT_LEFT, NavDirection.SHIFT_RIGHT})
+public @interface NavDirection {
+    int SHIFT_LEFT = 1;
+    int SHIFT_RIGHT = -1;
 }

--- a/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/OrderedStepNavigator.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/OrderedStepNavigator.java
@@ -50,6 +50,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 /**
  * The OrderedStepNavigator moves through a linear series of steps.
  * <p>
@@ -88,9 +90,9 @@ public class OrderedStepNavigator implements StepNavigator {
         return stepsById.get(identifier);
     }
 
-    @Nullable
+    @Nonnull
     @Override
-    public Step getNextStep(@Nullable Step step, @NonNull TaskResult taskResult) {
+    public StepAndNavDirection getNextStep(@Nullable Step step, @NonNull TaskResult taskResult) {
         // default to the first step
         int nextStepIndex = 0;
 
@@ -107,7 +109,7 @@ public class OrderedStepNavigator implements StepNavigator {
             return null;
         }
 
-        return steps.get(nextStepIndex);
+        return new StepAndNavDirection(steps.get(nextStepIndex), NavDirection.SHIFT_LEFT);
     }
 
     @Nullable

--- a/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/StepNavigator.kt
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/StepNavigator.kt
@@ -58,9 +58,9 @@ interface StepNavigator {
      *
      * @param step current step, or null if retrieving first step for TaskInfoView
      * @param taskResult current step result
-     * @return next step, or null if there is no next step
+     * @return next step and the navigation direction
      */
-    fun getNextStep(step: Step?, taskResult: TaskResult): Step?
+    fun getNextStep(step: Step?, taskResult: TaskResult): StepAndNavDirection
 
     /**
      * Get the step to go to before the given step.
@@ -86,3 +86,10 @@ interface StepNavigator {
      */
     fun getSteps(): List<Step>
 }
+
+/**
+ * StepAndNavDirection is a simple holder class to return a Tuple in getNextStep
+ */
+data class StepAndNavDirection(val step: Step?, val navDirection: Int = NavDirection.SHIFT_LEFT)
+
+

--- a/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/TreeNavigator.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/TreeNavigator.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import javax.annotation.Nonnull;
+
 public class TreeNavigator implements StepNavigator {
 
     /*
@@ -138,10 +140,11 @@ public class TreeNavigator implements StepNavigator {
         return this.stepsById.get(identifier);
     }
 
-    @Nullable
+    @Nonnull
     @Override
-    public Step getNextStep(@Nullable Step step, @NotNull TaskResult taskResult) {
-        return nextStepHelper(step, this.root, new AtomicBoolean(false));
+    public StepAndNavDirection getNextStep(@Nullable Step step, @NotNull TaskResult taskResult) {
+        Step nextStep = nextStepHelper(step, this.root, new AtomicBoolean(false));
+        return new StepAndNavDirection(nextStep, NavDirection.SHIFT_LEFT);
     }
 
     @Nullable

--- a/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/TreeNavigator.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/TreeNavigator.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.research.domain.task.navigation;
 
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -14,6 +15,7 @@ import org.sagebionetworks.research.domain.step.interfaces.SectionStep;
 import org.sagebionetworks.research.domain.step.interfaces.Step;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -36,6 +38,12 @@ public class TreeNavigator implements StepNavigator {
         @Nullable
         private final Step step;
 
+        // The parent node of this node, root nodes will have this as null
+        @Nullable
+        private final Node parent;
+
+        //
+
         /**
          * Constructs a new node from the given list of steps. This node will represent the root of a Tree in which
          * the steps are the children.
@@ -45,7 +53,8 @@ public class TreeNavigator implements StepNavigator {
          */
         private Node(@Nullable List<Step> steps) {
             this.step = null;
-            this.children = constructChildNodes(steps);
+            this.parent = null;
+            this.children = constructChildNodes(steps, null);
         }
 
         /**
@@ -54,10 +63,11 @@ public class TreeNavigator implements StepNavigator {
          * @param step
          *         the step to construct the node from.
          */
-        private Node(@NonNull Step step) {
+        private Node(@NonNull Step step, @Nullable Node parentNode) {
             this.step = step;
+            this.parent = parentNode;
             if (step instanceof SectionStep) {
-                this.children = constructChildNodes(((SectionStep) step).getSteps());
+                this.children = constructChildNodes(((SectionStep) step).getSteps(), this);
             } else {
                 this.children = null;
             }
@@ -79,11 +89,11 @@ public class TreeNavigator implements StepNavigator {
          *         the list of steps to construct nodes from.
          * @return An ImmutableList of nodes constructed from the given steps.
          */
-        private ImmutableList<Node> constructChildNodes(@Nullable List<Step> childSteps) {
+        private ImmutableList<Node> constructChildNodes(@Nullable List<Step> childSteps, @Nullable Node parentNode) {
             if (childSteps != null && !childSteps.isEmpty()) {
                 List<Node> children = new ArrayList<>();
                 for (Step childStep : childSteps) {
-                    children.add(new Node(childStep));
+                    children.add(new Node(childStep, parentNode));
                 }
 
                 ImmutableList.Builder<Node> builder = new ImmutableList.Builder<>();
@@ -102,7 +112,34 @@ public class TreeNavigator implements StepNavigator {
         private boolean isLeaf() {
             return this.children == null;
         }
+
+        /**
+         * @return a flattened list of all nodes within the tree
+         */
+        @NonNull
+        private List<Node> findAllNodes() {
+            List<Node> leafNodes = new ArrayList<>();
+            findAllNodesRecursively(leafNodes);
+            return leafNodes;
+        }
+
+        /**
+         * @return recursively traverse nodes until we have all the nodes in thge list
+         */
+        private void findAllNodesRecursively(List<Node> nodeListByRef) {
+            nodeListByRef.add(this);
+            if (children != null) {
+                for (Node child : children) {
+                    child.findAllNodesRecursively(nodeListByRef);
+                }
+            }
+        }
     }
+
+    /**
+     * The separator used when naming sub-steps within SectionSteps
+     */
+    public static final String SECTION_STEP_PREFIX_SEPARATOR = "_";
 
     // Stores the list of progressMarkers which are the identifiers of the steps which count
     // towards computing the progress. An empty list represents the absence of progress markers,
@@ -137,10 +174,95 @@ public class TreeNavigator implements StepNavigator {
     @Nullable
     @Override
     public Step getStep(@NotNull String identifier) {
-        return this.stepsById.get(identifier);
+        Step step = this.stepsById.get(identifier);
+        if (step == null) {
+            // Due to the way that SectionStep's sub-step identifiers are created in ResourceTaskRepository.
+            // There may be some step identifiers that are prefixed with their sub-step identifiers.
+            // However, we can detect for that scenario with isNestedWithinSectionSteps function.
+            step = findStepNestedWithinSectionSteps(identifier);
+        }
+        return step;
     }
 
-    @Nonnull
+    /**
+     * @param identifier to find at the end of the stepIdentifierPath
+     * @return true if we found the sub-step identifier at the end of the path,
+     *         and each part of the path is a section step containing the next part of the path.
+     */
+    @Nullable
+    private Step findStepNestedWithinSectionSteps(@NotNull String identifier) {
+        for (Node node: root.findAllNodes()) {
+            if (isValidNestedStep(node, identifier)) {
+                return node.step;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param node to check the validity of its path.
+     * @param matchingIdentifier that we are trying to match up with a valid leaf.
+     * @return true the path of the node corresponds
+     *         to the correct format of ResourceTaskRepository nested section steps.
+     */
+    private boolean isValidNestedStep(@NonNull Node node, @NonNull String matchingIdentifier) {
+        // Node must be a leaf to check for a valid nested step
+        if (node.step == null) {
+            return false;
+        }
+
+        // Create the path components to validate if the node's path
+        // conforms to how ResourceTaskRepository creates identifiers.
+        List<String> stepIdentifierPath = Arrays.asList(node.step.getIdentifier().split(SECTION_STEP_PREFIX_SEPARATOR));
+        if (stepIdentifierPath == null || node.parent == null || stepIdentifierPath.size() <= 0) {
+            return false;
+        }
+
+        int pathIndex = stepIdentifierPath.size();
+
+        // Make sure that the last part of the path is our matching identifier
+        if (!matchingIdentifier.equals(stepIdentifierPath.get(pathIndex - 1))) {
+            return false;
+        }
+
+        // Loop backwards and check that the node's nested step identifiers
+        // match how we expect the ResourceTaskRepository to make them.
+        Node parentNode = node;
+        do {
+            // Build the full identifier we expect for this node
+            List<String> currentPathToNode = stepIdentifierPath.subList(0, pathIndex);
+            String stepIdentifier = join(SECTION_STEP_PREFIX_SEPARATOR, currentPathToNode);
+
+            // If our expectedIdentifier doesn't match what the step identifier really is, it is not valid.
+            if (!(parentNode.step != null &&
+                    parentNode.step.getIdentifier().equals(stepIdentifier))) {
+                return false;
+            }
+            pathIndex--;
+            parentNode = parentNode.parent;
+        } while(parentNode != null);
+
+        // If we reached this point, all checks have passed and this is a valid nested step.
+        return true;
+    }
+
+    /**
+     * Unit testable join function.
+     * TextUtils.join() does not work with unit tests because it's in the Android framework.
+     */
+    @NonNull
+    private String join(@NonNull String delimiter, @NonNull List<String> parts) {
+        StringBuilder sb = new StringBuilder("");
+        for (int i = 0; i < parts.size(); i++) {
+            if (i > 0) {
+                sb.append(delimiter);
+            }
+            sb.append(parts.get(i));
+        }
+        return sb.toString();
+    }
+
+    @NotNull
     @Override
     public StepAndNavDirection getNextStep(@Nullable Step step, @NotNull TaskResult taskResult) {
         Step nextStep = nextStepHelper(step, this.root, new AtomicBoolean(false));

--- a/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/strategy/StrategyBasedNavigator.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/strategy/StrategyBasedNavigator.java
@@ -36,11 +36,14 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.jetbrains.annotations.NotNull;
+import org.sagebionetworks.research.domain.result.interfaces.NavigationResult;
 import org.sagebionetworks.research.domain.result.interfaces.Result;
 import org.sagebionetworks.research.domain.result.interfaces.TaskResult;
 import org.sagebionetworks.research.domain.step.interfaces.SectionStep;
 import org.sagebionetworks.research.domain.step.interfaces.Step;
 import org.sagebionetworks.research.domain.task.Task;
+import org.sagebionetworks.research.domain.task.navigation.NavDirection;
+import org.sagebionetworks.research.domain.task.navigation.StepAndNavDirection;
 import org.sagebionetworks.research.domain.task.navigation.StepNavigator;
 import org.sagebionetworks.research.domain.task.navigation.StepNavigatorFactory;
 import org.sagebionetworks.research.domain.task.navigation.TaskProgress;
@@ -49,7 +52,10 @@ import org.sagebionetworks.research.domain.task.navigation.strategy.StepNavigati
 import org.sagebionetworks.research.domain.task.navigation.strategy.StepNavigationStrategy.NextStepStrategy;
 import org.sagebionetworks.research.domain.task.navigation.strategy.StepNavigationStrategy.SkipStepStrategy;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 
 public class StrategyBasedNavigator implements StepNavigator {
     public static class Factory implements StepNavigatorFactory {
@@ -79,6 +85,31 @@ public class StrategyBasedNavigator implements StepNavigator {
         this.treeNavigator = new TreeNavigator(task.getSteps(), progressMarkers);
     }
 
+    /**
+     * Only supported return values are NavDirection values
+     * @param fromStep step to be considered where the user is currently
+     * @param toStep step to be considered where the user is going to go next
+     * @return the navigation direction moving from fromStep to toStep
+     */
+    private @NavDirection int getNextStepDirection(@Nullable final Step fromStep,
+            @Nullable final Step toStep, @NotNull final TaskResult taskResult) {
+
+        // The StrategyBasedNavigator's next step can potentially be a previously visited step.
+        // In that case, we want to identify it, and provide a more logical transition to the user with SHIFT_RIGHT.
+        if (fromStep != null && toStep != null) {
+            // This is a simple index check of step list order, more complex logic may be needed,
+            // If so, this can be adjusted, or getNextStepDirection can be overridden
+            int fromIndex = indexOfStep(fromStep);
+            int toIndex = indexOfStep(toStep);
+
+            if (toIndex < fromIndex) {
+                return NavDirection.SHIFT_RIGHT;
+            }
+        }
+
+        return NavDirection.SHIFT_LEFT;
+    }
+
     @Override
     @Nullable
     public Step getStep(@NonNull final String identifier) {
@@ -86,21 +117,28 @@ public class StrategyBasedNavigator implements StepNavigator {
     }
 
     @Override
-    @Nullable
-    public Step getNextStep(final Step step, @NonNull TaskResult taskResult) {
+    public @Nonnull StepAndNavDirection getNextStep(final Step step, @NonNull TaskResult taskResult) {
         Step nextStep = null;
-        // First we try to get the next step from the step by casting it to a NextStepStrategy.
-        if (step instanceof NextStepStrategy) {
+
+        // First we try to get the next step from the result by casting it to a NavigationResult
+        String skipToIdentifier = getSkipToIdentifierFromNavigationResult(step, taskResult);
+        if (skipToIdentifier != null) {
+            nextStep = treeNavigator.getStep(skipToIdentifier);
+        }
+
+        // If we don't get a valid step from casting the result to a NavigationResult,
+        // let's try to get the next step from the step by casting it to a NextStepStrategy.
+        if (nextStep == null && step instanceof NextStepStrategy) {
             String nextStepId = ((NextStepStrategy)step).getNextStepIdentifier(taskResult);
             if (nextStepId != null) {
                 nextStep = this.getStep(nextStepId);
             }
         }
 
-        // If we don't get a valid step from casting to a NextStepStrategy we default to using the tree navigator to
+        // If we didn't get a valid step from the previous checks, we default to using the tree navigator to
         // get the next step.
         if (nextStep == null) {
-            nextStep = treeNavigator.getNextStep(step, taskResult);
+            nextStep = treeNavigator.getNextStep(step, taskResult).getStep();
         }
 
         if (nextStep != null) {
@@ -109,7 +147,8 @@ public class StrategyBasedNavigator implements StepNavigator {
             // As long as the next step we have found shouldn't be skipped we return it.
             if (!(nextStep instanceof SkipStepStrategy) ||
                     !((SkipStepStrategy) nextStep).shouldSkip(taskResult)) {
-                return nextStep;
+                @NavDirection int navDirection = getNextStepDirection(step, nextStep, taskResult);
+                return new StepAndNavDirection(nextStep, navDirection);
             }
 
             // If we should skip the next step we found, we recurse on the next step to get the one after that.
@@ -117,7 +156,7 @@ public class StrategyBasedNavigator implements StepNavigator {
         }
 
         // If the tree navigator returns null we also return null.
-        return null;
+        return new StepAndNavDirection(null, NavDirection.SHIFT_LEFT);
     }
 
     @Override
@@ -170,5 +209,51 @@ public class StrategyBasedNavigator implements StepNavigator {
         }
 
         return step;
+    }
+
+    /**
+     * Performs a section resolved dive into indexing the steps to use for navigation direction
+     * @param step to find the index of
+     * @return the index of the step when the task steps are flattened
+     */
+    private int indexOfStep(Step step) {
+        List<Step> flattenedSteps = new ArrayList<>();
+        flattenTaskSteps(task.getSteps(), flattenedSteps);
+        return flattenedSteps.indexOf(step);
+    }
+
+    /**
+     * Builds a flattened list of steps from the task by resolving sections
+     * @param outStepList the pass by reference step list to keep adding steps to
+     */
+    private void flattenTaskSteps(@Nullable List<Step> inStepList, @Nonnull List<Step> outStepList) {
+        if (inStepList == null || inStepList.isEmpty()) {
+            return;
+        }
+        for (Step step : inStepList) {
+            if (step instanceof SectionStep) {
+                SectionStep sectionStep = (SectionStep)step;
+                outStepList.add(sectionStep);
+                flattenTaskSteps(sectionStep.getSteps(), outStepList);
+            } else {
+                outStepList.add(step);
+            }
+        }
+    }
+
+    /**
+     * @param step current step that would contain the possible NavigationResult
+     * @param taskResult current task result for the task
+     * @return an identifier that the navigator should skip to based on a specific NavigationResult scenario,
+     *         null otherwise.
+     */
+    private @Nullable String getSkipToIdentifierFromNavigationResult(Step step, TaskResult taskResult) {
+        if (step != null) {
+            Result result = taskResult.getResult(step);
+            if (result instanceof NavigationResult) {
+                return ((NavigationResult)result).getSkipToIdentifier();
+            }
+        }
+        return null;
     }
 }

--- a/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/strategy/StrategyBasedNavigator.java
+++ b/domain/src/main/java/org/sagebionetworks/research/domain/task/navigation/strategy/StrategyBasedNavigator.java
@@ -102,7 +102,8 @@ public class StrategyBasedNavigator implements StepNavigator {
             int fromIndex = indexOfStep(fromStep);
             int toIndex = indexOfStep(toStep);
 
-            if (toIndex < fromIndex) {
+            // If they are equal, then the step will be restarted and we should still show right transition
+            if (toIndex <= fromIndex) {
                 return NavDirection.SHIFT_RIGHT;
             }
         }

--- a/domain/src/test/java/org/sagebionetworks/research/domain/impl/SkipToStepActionImplTest.java
+++ b/domain/src/test/java/org/sagebionetworks/research/domain/impl/SkipToStepActionImplTest.java
@@ -35,10 +35,10 @@ package org.sagebionetworks.research.domain.impl;
 import org.junit.Test;
 
 public class SkipToStepActionImplTest extends IndividualActionTest {
-    public static final SkipToStepActionImpl COMPLETE = SkipToStepActionImpl.builder().setButtonIconName("icon")
-            .setButtonTitle("title").setSkipToStepIdentifier("skipTo").build();
+    public static final SkipToActionImpl COMPLETE = SkipToActionImpl.builder().setButtonIconName("icon")
+            .setButtonTitle("title").setSkipToIdentifier("skipTo").build();
 
-    public static final SkipToStepActionImpl NO_SKIP_TO = SkipToStepActionImpl.builder().setButtonIconName("icon")
+    public static final SkipToActionImpl NO_SKIP_TO = SkipToActionImpl.builder().setButtonIconName("icon")
             .setButtonTitle("title").build();
 
     @Test

--- a/domain/src/test/java/org/sagebionetworks/research/domain/navigation/IndividualNavigatorTest.java
+++ b/domain/src/test/java/org/sagebionetworks/research/domain/navigation/IndividualNavigatorTest.java
@@ -102,6 +102,24 @@ public abstract class IndividualNavigatorTest {
         return taskResult;
     }
 
+    public static TaskResult mockTaskResultFromResultsAndSteps(String identifier, List<Step> steps, List<Result> stepResults) {
+        TaskResult taskResult = mock(TaskResult.class);
+        for (int i = 0; i < steps.size(); i++) {
+            Result stepResult = stepResults.get(i);
+            Step step = steps.get(i);
+            String resultIdentifier = stepResult.getIdentifier();
+            when(taskResult.getResult(resultIdentifier)).thenReturn(stepResult);
+            when(taskResult.getResult(step)).thenReturn(stepResult);
+        }
+
+        ImmutableList.Builder<Result> builder = new ImmutableList.Builder<>();
+        builder.addAll(stepResults);
+        ImmutableList<Result> stepHistory = builder.build();
+        when(taskResult.getStepHistory()).thenReturn(stepHistory);
+        when(taskResult.getIdentifier()).thenReturn(identifier);
+        return taskResult;
+    }
+
     public IndividualNavigatorTest(StepNavigator navigator) {
         this.navigator = navigator;
         this.steps = TEST_STEPS;
@@ -158,7 +176,7 @@ public abstract class IndividualNavigatorTest {
     @Test
     public void testForward_From2() {
         TaskResult taskResult = mockTaskResult("task", steps.subList(0, 2));
-        Step nextStep = navigator.getNextStep(steps.get(2), taskResult);
+        Step nextStep = navigator.getNextStep(steps.get(2), taskResult).getStep();
         assertNotNull(nextStep);
         assertEquals("step3", nextStep.getIdentifier());
     }
@@ -176,7 +194,7 @@ public abstract class IndividualNavigatorTest {
         SectionStep step5 = (SectionStep) steps.get(5);
         stepHistory.add(mockTaskResult(step5.getIdentifier(), new ArrayList<Step>()));
         TaskResult taskResult = mockTaskResultFromResults("task", stepHistory);
-        Step nextStep = navigator.getNextStep(step5.getSteps().get(0), taskResult);
+        Step nextStep = navigator.getNextStep(step5.getSteps().get(0), taskResult).getStep();
         assertNotNull(nextStep);
         assertEquals("step5.Y", nextStep.getIdentifier());
     }
@@ -193,7 +211,7 @@ public abstract class IndividualNavigatorTest {
         SectionStep step5 = (SectionStep) steps.get(5);
         stepHistory.add(mockTaskResult(step5.getIdentifier(), step5.getSteps().subList(0, 2)));
         TaskResult taskResult = mockTaskResultFromResults("task", stepHistory);
-        Step nextStep = navigator.getNextStep(step5.getSteps().get(2), taskResult);
+        Step nextStep = navigator.getNextStep(step5.getSteps().get(2), taskResult).getStep();
         assertNotNull(nextStep);
         assertEquals("step6.A", nextStep.getIdentifier());
     }

--- a/domain/src/test/java/org/sagebionetworks/research/domain/navigation/StrategyBasedNavigatorTest.java
+++ b/domain/src/test/java/org/sagebionetworks/research/domain/navigation/StrategyBasedNavigatorTest.java
@@ -315,12 +315,11 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
         Task task = mockTask(steps, TEST_PROGRESS_MARKERS);
         StrategyBasedNavigator navigator = new StrategyBasedNavigator(task, TEST_PROGRESS_MARKERS);
 
+        // Remove the last navigation result so we just go to end of the task
         List<Result> stepHistory = new ArrayList<>();
         stepHistory.add(new NavigationResultBase("step1", Instant.EPOCH, Instant.EPOCH, "step3"));
         stepHistory.add(new ResultBase("step2", Instant.EPOCH, Instant.EPOCH));
-        stepHistory.add(new NavigationAnswerResultBase<>("step3", Instant.EPOCH, Instant.EPOCH,
-                10, ResultType.ANSWER, "step2"));
-        TaskResult taskResult = mockTaskResultFromResultsAndSteps("task", steps, stepHistory);
+        TaskResult taskResult = mockTaskResultFromResultsAndSteps("task", steps.subList(0, 2), stepHistory);
 
         StepAndNavDirection nextStepAndDirection = navigator.getNextStep(null, taskResult);
         assertEquals(NavDirection.SHIFT_LEFT, nextStepAndDirection.getNavDirection());
@@ -332,6 +331,13 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
         assertNotNull(nextStepAndDirection.getStep());
         assertEquals("step3", nextStepAndDirection.getStep().getIdentifier());
 
+        // Remove the last navigation result so we just go to end of the task
+        stepHistory = new ArrayList<>();
+        stepHistory.add(new NavigationResultBase("step1", Instant.EPOCH, Instant.EPOCH, "step3"));
+        stepHistory.add(new ResultBase("step2", Instant.EPOCH, Instant.EPOCH));
+        stepHistory.add(new NavigationResultBase("step3", Instant.EPOCH, Instant.EPOCH, "step2"));
+        taskResult = mockTaskResultFromResultsAndSteps("task", steps, stepHistory);
+
         nextStepAndDirection = navigator.getNextStep(nextStepAndDirection.getStep(), taskResult);
         assertEquals(NavDirection.SHIFT_RIGHT, nextStepAndDirection.getNavDirection());
         assertNotNull(nextStepAndDirection.getStep());
@@ -342,8 +348,10 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
         assertNotNull(nextStepAndDirection.getStep());
         assertEquals("step3", nextStepAndDirection.getStep().getIdentifier());
 
-        // Remove the last navigation result so we just go to end of the task
-        stepHistory.set(2, new ResultBase("step3", Instant.EPOCH, Instant.EPOCH));
+        stepHistory = new ArrayList<>();
+        stepHistory.add(new NavigationResultBase("step1", Instant.EPOCH, Instant.EPOCH, "step3"));
+        stepHistory.add(new ResultBase("step2", Instant.EPOCH, Instant.EPOCH));
+        stepHistory.add(new ResultBase("step3", Instant.EPOCH, Instant.EPOCH));
         taskResult = mockTaskResultFromResultsAndSteps("task", steps, stepHistory);
 
         nextStepAndDirection = navigator.getNextStep(nextStepAndDirection.getStep(), taskResult);

--- a/domain/src/test/java/org/sagebionetworks/research/domain/navigation/StrategyBasedNavigatorTest.java
+++ b/domain/src/test/java/org/sagebionetworks/research/domain/navigation/StrategyBasedNavigatorTest.java
@@ -10,28 +10,34 @@ import static junit.framework.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
-import com.google.common.collect.ImmutableList;
-
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
+import org.sagebionetworks.research.domain.result.ResultType;
+import org.sagebionetworks.research.domain.result.implementations.NavigationAnswerResultBase;
+import org.sagebionetworks.research.domain.result.implementations.NavigationResultBase;
+import org.sagebionetworks.research.domain.result.implementations.ResultBase;
+import org.sagebionetworks.research.domain.result.implementations.TaskResultBase;
 import org.sagebionetworks.research.domain.result.interfaces.Result;
 import org.sagebionetworks.research.domain.result.interfaces.TaskResult;
 import org.sagebionetworks.research.domain.step.interfaces.SectionStep;
 import org.sagebionetworks.research.domain.step.interfaces.Step;
 import org.sagebionetworks.research.domain.task.Task;
-import org.sagebionetworks.research.domain.task.Task;
+import org.sagebionetworks.research.domain.task.navigation.NavDirection;
+import org.sagebionetworks.research.domain.task.navigation.StepAndNavDirection;
 import org.sagebionetworks.research.domain.task.navigation.TaskProgress;
 import org.sagebionetworks.research.domain.task.navigation.strategy.StepNavigationStrategy.BackStepStrategy;
 import org.sagebionetworks.research.domain.task.navigation.strategy.StepNavigationStrategy.NextStepStrategy;
 import org.sagebionetworks.research.domain.task.navigation.strategy.StepNavigationStrategy.SkipStepStrategy;
 import org.sagebionetworks.research.domain.task.navigation.strategy.StrategyBasedNavigator;
+import org.threeten.bp.Instant;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
     private static final String SKIP_RESULT_IDENTIFIER = "skip";
@@ -120,7 +126,7 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
     public void testNext_From3() {
         TaskResult taskResult = mockTaskResult("task", STRATEGY_TEST_STEPS.subList(0, 3));
         // Step 3 has a next rule which returns "step1" so we should move on to step1.
-        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(STRATEGY_TEST_STEPS.get(3), taskResult);
+        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(STRATEGY_TEST_STEPS.get(3), taskResult).getStep();
         assertNotNull(nextStep);
         assertEquals("step1", nextStep.getIdentifier());
     }
@@ -130,7 +136,7 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
     public void testNext_FromIntroduction() {
         TaskResult taskResult = mockTaskResult("task", new ArrayList<Step>());
         // The introduction step has a next rule which returns "step2" so we should move on to step2.
-        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(STRATEGY_TEST_STEPS.get(0), taskResult);
+        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(STRATEGY_TEST_STEPS.get(0), taskResult).getStep();
         assertNotNull(nextStep);
         assertEquals("step2", nextStep.getIdentifier());
     }
@@ -147,7 +153,7 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
         TaskResult taskResult = mockTaskResultFromResults("task", stepHistory);
         // step5.Y has a next rule returns "step7" so we should move on to step7.
         SectionStep step5 = (SectionStep) STRATEGY_TEST_STEPS.get(5);
-        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(step5.getSteps().get(1), taskResult);
+        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(step5.getSteps().get(1), taskResult).getStep();
         assertNotNull(nextStep);
         assertEquals("step7", nextStep.getIdentifier());
     }
@@ -164,7 +170,7 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
         TaskResult taskResult = mockTaskResultFromResults("task", stepHistory);
         // step5.Z has a next rule returns "step4.B" so we should move on to step4.B.
         SectionStep step5 = (SectionStep) STRATEGY_TEST_STEPS.get(5);
-        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(step5.getSteps().get(2), taskResult);
+        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(step5.getSteps().get(2), taskResult).getStep();
         assertNotNull(nextStep);
         assertEquals("step4.B", nextStep.getIdentifier());
     }
@@ -181,7 +187,7 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
         stepHistory.add(mockSectionResult(STRATEGY_TEST_STEPS.get(6), 0, 3));
         TaskResult taskResult = mockTaskResultFromResults("task", stepHistory);
         // step7 has a next rule returns "step6.A" so we should move on to step6.A.
-        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(STRATEGY_TEST_STEPS.get(7), taskResult);
+        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(STRATEGY_TEST_STEPS.get(7), taskResult).getStep();
         assertNotNull(nextStep);
         assertEquals("step6.A", nextStep.getIdentifier());
     }
@@ -193,7 +199,7 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
         TaskResult taskResult = mockTaskResult("task", STRATEGY_TEST_STEPS.subList(0, 2));
         // Step 2 returns null for it's next step identifier so the default behaviour should kick in and we should
         // move on to step3.
-        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(STRATEGY_TEST_STEPS.get(2), taskResult);
+        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(STRATEGY_TEST_STEPS.get(2), taskResult).getStep();
         assertNotNull(nextStep);
         assertEquals("step3", nextStep.getIdentifier());
     }
@@ -221,7 +227,7 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
         }
         TaskResult taskResult = mockTaskResultFromResults("task", stepHistory);
         // From step1, step2 shouldn't be skipped so we should end up there.
-        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(STRATEGY_TEST_STEPS.get(1), taskResult);
+        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(STRATEGY_TEST_STEPS.get(1), taskResult).getStep();
         assertNotNull(nextStep);
         assertEquals("step2", nextStep.getIdentifier());
     }
@@ -238,7 +244,7 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
         TaskResult taskResult = mockTaskResultFromResults("task", stepHistory);
         // From step4.C, we should go directly to step5.X since this step shouldn't be skipped.
         SectionStep step4 = (SectionStep) STRATEGY_TEST_STEPS.get(4);
-        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(step4.getSteps().get(2), taskResult);
+        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(step4.getSteps().get(2), taskResult).getStep();
         assertNotNull(nextStep);
         assertEquals("step5.X", nextStep.getIdentifier());
     }
@@ -253,7 +259,7 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
         }
         TaskResult taskResult = mockTaskResultFromResults("task", stepHistory);
         // From step1 we should go directly to step 3 since step 2 should be skipped.
-        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(STRATEGY_TEST_STEPS.get(1), taskResult);
+        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(STRATEGY_TEST_STEPS.get(1), taskResult).getStep();
         assertNotNull(nextStep);
         assertEquals("step3", nextStep.getIdentifier());
     }
@@ -270,7 +276,7 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
         TaskResult taskResult = mockTaskResultFromResults("task", stepHistory);
         // From step4.C, we should go directly to step5.Y since step5.X should be skipped.
         SectionStep step4 = (SectionStep) STRATEGY_TEST_STEPS.get(4);
-        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(step4.getSteps().get(2), taskResult);
+        Step nextStep = STRATEGY_TEST_NAVIGATOR.getNextStep(step4.getSteps().get(2), taskResult).getStep();
         assertNotNull(nextStep);
         assertEquals("step5.Y", nextStep.getIdentifier());
     }
@@ -301,6 +307,48 @@ public class StrategyBasedNavigatorTest extends IndividualNavigatorTest {
         }
 
         return step;
+    }
+
+    @Test
+    public void test_NavigationResultBase() {
+        List<Step> steps = Arrays.asList(mockStep("step1"), mockStep("step2"), mockStep("step3"));
+        Task task = mockTask(steps, TEST_PROGRESS_MARKERS);
+        StrategyBasedNavigator navigator = new StrategyBasedNavigator(task, TEST_PROGRESS_MARKERS);
+
+        List<Result> stepHistory = new ArrayList<>();
+        stepHistory.add(new NavigationResultBase("step1", Instant.EPOCH, Instant.EPOCH, "step3"));
+        stepHistory.add(new ResultBase("step2", Instant.EPOCH, Instant.EPOCH));
+        stepHistory.add(new NavigationAnswerResultBase<>("step3", Instant.EPOCH, Instant.EPOCH,
+                10, ResultType.ANSWER, "step2"));
+        TaskResult taskResult = mockTaskResultFromResultsAndSteps("task", steps, stepHistory);
+
+        StepAndNavDirection nextStepAndDirection = navigator.getNextStep(null, taskResult);
+        assertEquals(NavDirection.SHIFT_LEFT, nextStepAndDirection.getNavDirection());
+        assertNotNull(nextStepAndDirection.getStep());
+        assertEquals("step1", nextStepAndDirection.getStep().getIdentifier());
+
+        nextStepAndDirection = navigator.getNextStep(nextStepAndDirection.getStep(), taskResult);
+        assertEquals(NavDirection.SHIFT_LEFT, nextStepAndDirection.getNavDirection());
+        assertNotNull(nextStepAndDirection.getStep());
+        assertEquals("step3", nextStepAndDirection.getStep().getIdentifier());
+
+        nextStepAndDirection = navigator.getNextStep(nextStepAndDirection.getStep(), taskResult);
+        assertEquals(NavDirection.SHIFT_RIGHT, nextStepAndDirection.getNavDirection());
+        assertNotNull(nextStepAndDirection.getStep());
+        assertEquals("step2", nextStepAndDirection.getStep().getIdentifier());
+
+        nextStepAndDirection = navigator.getNextStep(nextStepAndDirection.getStep(), taskResult);
+        assertEquals(NavDirection.SHIFT_LEFT, nextStepAndDirection.getNavDirection());
+        assertNotNull(nextStepAndDirection.getStep());
+        assertEquals("step3", nextStepAndDirection.getStep().getIdentifier());
+
+        // Remove the last navigation result so we just go to end of the task
+        stepHistory.set(2, new ResultBase("step3", Instant.EPOCH, Instant.EPOCH));
+        taskResult = mockTaskResultFromResultsAndSteps("task", steps, stepHistory);
+
+        nextStepAndDirection = navigator.getNextStep(nextStepAndDirection.getStep(), taskResult);
+        assertEquals(NavDirection.SHIFT_LEFT, nextStepAndDirection.getNavDirection());
+        assertNull(nextStepAndDirection.getStep());
     }
 
     static {

--- a/domain/src/test/java/org/sagebionetworks/research/domain/navigation/TreeNavigatorTest.java
+++ b/domain/src/test/java/org/sagebionetworks/research/domain/navigation/TreeNavigatorTest.java
@@ -4,12 +4,16 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 
+import static org.junit.Assert.assertNull;
+
 import org.junit.Test;
 import org.sagebionetworks.research.domain.result.interfaces.TaskResult;
 import org.sagebionetworks.research.domain.step.interfaces.Step;
 import org.sagebionetworks.research.domain.task.navigation.TaskProgress;
 import org.sagebionetworks.research.domain.task.navigation.TreeNavigator;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class TreeNavigatorTest extends IndividualNavigatorTest {
@@ -32,5 +36,103 @@ public class TreeNavigatorTest extends IndividualNavigatorTest {
         assertTrue(progress.isEstimated());
     }
     // endregion
+    @Test
+    public void testGetStep_OneSectionDeep() {
+        List<Step> steps1 = createSteps(new String[]{"1_a", "1_b"});
+        List<Step> steps2 = createSteps(new String[]{"2_a", "2_b", "3_c"});
+        List<Step> steps = Arrays.asList(new Step[] {
+                mockSectionStep("1", steps1),
+                mockSectionStep("2", steps2) });
+
+        TreeNavigator navigator = new TreeNavigator(steps, null);
+
+        Step section1 = navigator.getStep("1");
+        assertNotNull(section1);
+        assertEquals("1", section1.getIdentifier());
+
+        Step section2 = navigator.getStep("2");
+        assertNotNull(section2);
+        assertEquals("2", section2.getIdentifier());
+
+        Step firstAStep = navigator.getStep("a");
+        assertNotNull(firstAStep);
+        assertEquals("1_a", firstAStep.getIdentifier());
+
+        Step firstBStep = navigator.getStep("b");
+        assertNotNull(firstBStep);
+        assertEquals("1_b", firstBStep.getIdentifier());
+
+        // "c" fails the upwards navigation sub-step format because it's step identifier
+        // implies that it's section step should have identifier "3", but it actually has identifier "2"
+        Step cStepNull = navigator.getStep("c");
+        assertNull(cStepNull);
+
+        Step cStep = navigator.getStep("3_c");
+        assertNotNull(cStep);
+        assertEquals("3_c", cStep.getIdentifier());
+    }
+
+    @Test
+    public void testGetStep_TwoSectionsDeep() {
+        List<Step> steps1_3 = createSteps(new String[]{"1_3_a", "1_3_b"});
+        List<Step> steps2_4 = createSteps(new String[]{"2_4_a", "2_4_b", "1_4_c", "2_3_e"});
+
+        Step sectionStep1 = mockSectionStep("1", Arrays.asList(
+                mockSectionStep("1_3", steps1_3),
+                mockStep("1_d")));
+
+        Step sectionStep2 = mockSectionStep("2", Arrays.asList(
+                mockSectionStep("2_4", steps2_4),
+                mockStep("2_d")));
+
+        List<Step> steps = Arrays.asList(sectionStep1, sectionStep2, mockStep("5"));
+
+        TreeNavigator navigator = new TreeNavigator(steps, null);
+
+        Step section1 = navigator.getStep("1");
+        assertNotNull(section1);
+        assertEquals("1", section1.getIdentifier());
+
+        Step section2 = navigator.getStep("2");
+        assertNotNull(section2);
+        assertEquals("2", section2.getIdentifier());
+
+        Step section3 = navigator.getStep("3");
+        assertNotNull(section3);
+        assertEquals("1_3", section3.getIdentifier());
+
+        Step section4 = navigator.getStep("4");
+        assertNotNull(section4);
+        assertEquals("2_4", section4.getIdentifier());
+
+        Step step_1_3_a = navigator.getStep("a");
+        assertNotNull(step_1_3_a);
+        assertEquals("1_3_a", step_1_3_a.getIdentifier());
+
+        Step step_2_4_a = navigator.getStep("2_4_a");
+        assertNotNull(step_2_4_a);
+        assertEquals("2_4_a", step_2_4_a.getIdentifier());
+
+        Step step_1_3_b = navigator.getStep("b");
+        assertNotNull(step_1_3_b);
+        assertEquals("1_3_b", step_1_3_b.getIdentifier());
+
+        Step step_2_4_b = navigator.getStep("2_4_b");
+        assertNotNull(step_2_4_b);
+        assertEquals("2_4_b", step_2_4_b.getIdentifier());
+
+        // "e" fails the upwards navigation sub-step format because it's step identifier
+        // implies that it's section step should have identifier "4", but it actually has identifier "3"
+        Step dStepNull = navigator.getStep("e");
+        assertNull(dStepNull);
+
+        Step step_1_d = navigator.getStep("d");
+        assertNotNull(step_1_d);
+        assertEquals("1_d", step_1_d.getIdentifier());
+
+        Step step_2_3_e = navigator.getStep("2_3_e");
+        assertNotNull(step_2_3_e);
+        assertEquals("2_3_e", step_2_3_e.getIdentifier());
+    }
 }
 

--- a/domain/src/test/resources/actions/SkipToStepAction_Complete.json
+++ b/domain/src/test/resources/actions/SkipToStepAction_Complete.json
@@ -2,5 +2,5 @@
   "type": "navigation",
   "buttonIcon": "icon",
   "buttonTitle": "title",
-  "skipToStepIdentifier": "skipTo"
+  "skipToIdentifier": "skipTo"
 }

--- a/mobile-ui/src/main/java/org/sagebionetworks/research/mobile_ui/show_step/view/ShowActiveUIStepFragmentBase.java
+++ b/mobile-ui/src/main/java/org/sagebionetworks/research/mobile_ui/show_step/view/ShowActiveUIStepFragmentBase.java
@@ -45,10 +45,12 @@ import android.view.animation.LinearInterpolator;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import org.sagebionetworks.research.domain.result.implementations.ResultBase;
 import org.sagebionetworks.research.mobile_ui.show_step.view.view_binding.ActiveUIStepViewBinding;
 import org.sagebionetworks.research.presentation.model.action.ActionType;
 import org.sagebionetworks.research.presentation.model.interfaces.ActiveUIStepView;
 import org.sagebionetworks.research.presentation.show_step.show_step_view_models.ShowActiveUIStepViewModel;
+import org.threeten.bp.Instant;
 
 public abstract class ShowActiveUIStepFragmentBase<S extends ActiveUIStepView, VM extends ShowActiveUIStepViewModel<S>,
         SB extends ActiveUIStepViewBinding<S>> extends
@@ -93,6 +95,7 @@ public abstract class ShowActiveUIStepFragmentBase<S extends ActiveUIStepView, V
 
             if (count == 0) {
                 // TODO rkolmos 07/24/2018 implement commands and fix this to not always go forward
+                addStepResultAfterCountdown();
                 showStepViewModel.handleAction(ActionType.FORWARD);
                 return;
             }
@@ -132,5 +135,16 @@ public abstract class ShowActiveUIStepFragmentBase<S extends ActiveUIStepView, V
         }
 
         return null;
+    }
+
+    /**
+     * Add the basic step result to mark the step as completed, can be overridden for custom results.
+     */
+    protected void addStepResultAfterCountdown() {
+        // Because we use SkipToActionView, we must explicitly set a base result to move forward normally
+        // Usually, this is done automatically in showStepViewModel.handleAction(),
+        // But, if we already have NavigationResult, it won't create the default one to navigate normally.
+        performTaskViewModel.addStepResult(
+                new ResultBase(stepView.getIdentifier(), showStepViewModel.getStartTime(), Instant.now()));
     }
 }

--- a/mobile-ui/src/main/java/org/sagebionetworks/research/mobile_ui/show_step/view/ShowActiveUIStepFragmentBase.java
+++ b/mobile-ui/src/main/java/org/sagebionetworks/research/mobile_ui/show_step/view/ShowActiveUIStepFragmentBase.java
@@ -52,6 +52,8 @@ import org.sagebionetworks.research.presentation.model.interfaces.ActiveUIStepVi
 import org.sagebionetworks.research.presentation.show_step.show_step_view_models.ShowActiveUIStepViewModel;
 import org.threeten.bp.Instant;
 
+import java.util.Locale;
+
 public abstract class ShowActiveUIStepFragmentBase<S extends ActiveUIStepView, VM extends ShowActiveUIStepViewModel<S>,
         SB extends ActiveUIStepViewBinding<S>> extends
         ShowUIStepFragmentBase<S, VM, SB> {
@@ -70,7 +72,7 @@ public abstract class ShowActiveUIStepFragmentBase<S extends ActiveUIStepView, V
 
         TextView countLabel = this.stepViewBinding.getCountLabel();
         if (countLabel != null) {
-            countLabel.setText(duration.toString());
+            countLabel.setText(String.format(duration.toString(), Locale.getDefault()));
         }
 
         Observer<Long> countdownObserver = this.getCountdownObserver();

--- a/mobile-ui/src/main/java/org/sagebionetworks/research/mobile_ui/show_step/view/ShowCountdownStepFragment.java
+++ b/mobile-ui/src/main/java/org/sagebionetworks/research/mobile_ui/show_step/view/ShowCountdownStepFragment.java
@@ -3,13 +3,21 @@ package org.sagebionetworks.research.mobile_ui.show_step.view;
 import android.os.Bundle;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
 import android.view.View;
 
 import org.sagebionetworks.research.mobile_ui.R;
 import org.sagebionetworks.research.mobile_ui.perform_task.PerformTaskFragment;
 import org.sagebionetworks.research.mobile_ui.show_step.view.view_binding.ActiveUIStepViewBinding;
+import org.sagebionetworks.research.mobile_ui.widget.ActionButton;
+import org.sagebionetworks.research.presentation.DisplayString;
+import org.sagebionetworks.research.presentation.model.action.ActionType;
+import org.sagebionetworks.research.presentation.model.action.ActionView;
+import org.sagebionetworks.research.presentation.model.action.ActionViewBase;
+import org.sagebionetworks.research.presentation.model.action.SkipToActionView;
 import org.sagebionetworks.research.presentation.model.interfaces.CountdownStepView;
 import org.sagebionetworks.research.presentation.model.interfaces.StepView;
+import org.sagebionetworks.research.presentation.model.interfaces.UIStepView;
 import org.sagebionetworks.research.presentation.show_step.show_step_view_models.ShowActiveUIStepViewModel;
 
 public class ShowCountdownStepFragment extends ShowActiveUIStepFragmentBase<CountdownStepView,
@@ -17,7 +25,9 @@ public class ShowCountdownStepFragment extends ShowActiveUIStepFragmentBase<Coun
     @Override
     public void onStart() {
         super.onStart();
-        this.showStepViewModel.startCountdown();
+        if (!showStepViewModel.isCountdownStarted()) {
+            showStepViewModel.startCountdown();
+        }
     }
 
     @NonNull
@@ -43,5 +53,46 @@ public class ShowCountdownStepFragment extends ShowActiveUIStepFragmentBase<Coun
     @NonNull
     protected ActiveUIStepViewBinding<CountdownStepView> instantiateAndBindBinding(View view) {
         return new ActiveUIStepViewBinding<>(view);
+    }
+
+    @Override
+    protected ActionView getForwardButtonActionView(UIStepView stepView) {
+        // Unless specified in JSON or through a sub-class, countdown should have a pause/resume button.
+        return ActionViewBase.builder()
+                .setButtonTitle(DisplayString.create(null, getPauseResumeCountdownButtonTitle()))
+                .build();
+    }
+
+    /**
+     * Called whenever one of this fragment's ActionButton's is clicked.
+     * @param actionButton the ActionButton that was clicked by the user.
+     */
+    @Override
+    protected void handleActionButtonClick(@NonNull ActionButton actionButton) {
+        @ActionType String actionType = this.getActionTypeFromActionButton(actionButton);
+        if (actionType.equals(ActionType.FORWARD)) {
+            if (showStepViewModel.isCountdownStarted()) {
+                showStepViewModel.pauseCountdown();
+            } else {
+                showStepViewModel.resumeCountdown();
+            }
+            ActionButton pauseResumeButton = stepViewBinding.getNextButton();
+            if (pauseResumeButton != null) {
+                pauseResumeButton.setText(getPauseResumeCountdownButtonTitle());
+            }
+        } else {
+            super.handleActionButtonClick(actionButton);
+        }
+    }
+
+    /**
+     * @return the proper title for the countdown pause/resume button.
+     */
+    private String getPauseResumeCountdownButtonTitle() {
+        if (showStepViewModel.isCountdownStarted()) {
+            return getResources().getString(R.string.countdown_pause);
+        } else {
+            return getResources().getString(R.string.countdown_resume);
+        }
     }
 }

--- a/mobile-ui/src/main/java/org/sagebionetworks/research/mobile_ui/show_step/view/ShowCountdownStepFragment.java
+++ b/mobile-ui/src/main/java/org/sagebionetworks/research/mobile_ui/show_step/view/ShowCountdownStepFragment.java
@@ -22,10 +22,11 @@ import org.sagebionetworks.research.presentation.show_step.show_step_view_models
 
 public class ShowCountdownStepFragment extends ShowActiveUIStepFragmentBase<CountdownStepView,
         ShowActiveUIStepViewModel<CountdownStepView>, ActiveUIStepViewBinding<CountdownStepView>> {
+
     @Override
     public void onStart() {
         super.onStart();
-        if (!showStepViewModel.isCountdownStarted()) {
+        if (!showStepViewModel.isCountdownRunning() && !showStepViewModel.isCountdownPaused()) {
             showStepViewModel.startCountdown();
         }
     }
@@ -71,7 +72,7 @@ public class ShowCountdownStepFragment extends ShowActiveUIStepFragmentBase<Coun
     protected void handleActionButtonClick(@NonNull ActionButton actionButton) {
         @ActionType String actionType = this.getActionTypeFromActionButton(actionButton);
         if (actionType.equals(ActionType.FORWARD)) {
-            if (showStepViewModel.isCountdownStarted()) {
+            if (showStepViewModel.isCountdownRunning()) {
                 showStepViewModel.pauseCountdown();
             } else {
                 showStepViewModel.resumeCountdown();
@@ -89,7 +90,7 @@ public class ShowCountdownStepFragment extends ShowActiveUIStepFragmentBase<Coun
      * @return the proper title for the countdown pause/resume button.
      */
     private String getPauseResumeCountdownButtonTitle() {
-        if (showStepViewModel.isCountdownStarted()) {
+        if (showStepViewModel.isCountdownRunning()) {
             return getResources().getString(R.string.countdown_pause);
         } else {
             return getResources().getString(R.string.countdown_resume);

--- a/mobile-ui/src/main/java/org/sagebionetworks/research/mobile_ui/widget/StepSwitcher.java
+++ b/mobile-ui/src/main/java/org/sagebionetworks/research/mobile_ui/widget/StepSwitcher.java
@@ -40,8 +40,8 @@ import android.view.View;
 import android.view.animation.DecelerateInterpolator;
 import android.widget.FrameLayout;
 
+import org.sagebionetworks.research.domain.task.navigation.NavDirection;
 import org.sagebionetworks.research.mobile_ui.R;
-import org.sagebionetworks.research.presentation.model.interfaces.StepView.NavDirection;
 
 /**
  * Base class for a {@link FrameLayout} container that will perform animations when switching between two steps. There

--- a/mobile-ui/src/main/res/values/strings.xml
+++ b/mobile-ui/src/main/res/values/strings.xml
@@ -32,6 +32,9 @@
 
 <resources>
     <!-- TODO: Remove or change this placeholder text -->
+    <string name="countdown_pause">Pause</string>
+    <string name="countdown_resume">Resume</string>
+
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="rs2_remind_later">Remind me later</string>
     <string name="tap_button_text">Tap</string>

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/model/BaseStepView.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/model/BaseStepView.java
@@ -41,7 +41,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 
-import org.sagebionetworks.research.domain.result.interfaces.TaskResult;
 import org.sagebionetworks.research.domain.step.StepType;
 import org.sagebionetworks.research.domain.step.interfaces.Step;
 import org.sagebionetworks.research.presentation.model.interfaces.StepView;
@@ -64,8 +63,6 @@ public abstract class BaseStepView implements StepView, Parcelable {
 
         public abstract Builder setIdentifier(@NonNull String identifier);
 
-        public abstract Builder setNavDirection(@NavDirection int navDirection);
-
         public abstract Builder setStepActionViews(@NonNull Set<StepActionView> stepActionViews);
 
         public abstract Builder setTitle(@Nullable String title);
@@ -73,7 +70,6 @@ public abstract class BaseStepView implements StepView, Parcelable {
 
     public static Builder builder() {
         return new AutoValue_BaseStepView.Builder()
-                .setNavDirection(NavDirection.SHIFT_LEFT)
                 .setStepActionViews(Collections.emptySet());
     }
 
@@ -86,8 +82,6 @@ public abstract class BaseStepView implements StepView, Parcelable {
 
     @NonNull
     public abstract String getIdentifier();
-
-    public abstract int getNavDirection();
 
     @NonNull
     public abstract ImmutableSet<StepActionView> getStepActionViews();

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/model/action/SkipToActionView.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/model/action/SkipToActionView.java
@@ -34,7 +34,7 @@ package org.sagebionetworks.research.presentation.model.action;
 
 import javax.annotation.Nullable;
 
-public interface SkipToStepActionView extends ActionView {
+public interface SkipToActionView extends ActionView {
     @Nullable
-    String getSkipToStepIdentifier();
+    String getSkipToIdentifier();
 }

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/model/action/SkipToActionViewBase.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/model/action/SkipToActionViewBase.java
@@ -30,16 +30,38 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.sagebionetworks.research.domain.step.ui.action;
+package org.sagebionetworks.research.presentation.model.action;
 
-import android.support.annotation.Nullable;
+import com.google.auto.value.AutoValue;
 
-public interface SkipToStepAction extends Action {
-    /**
-     * Returns the identifier of the step to skip to for this action.
-     *
-     * @return the identifier of the step to skip to fro this action.
-     */
-    @Nullable
-    String getSkipToStepIdentifier();
+import org.sagebionetworks.research.domain.step.ui.action.SkipToAction;
+import org.sagebionetworks.research.presentation.DisplayDrawable;
+import org.sagebionetworks.research.presentation.DisplayString;
+
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class SkipToActionViewBase implements SkipToActionView {
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract SkipToActionViewBase build();
+
+        public abstract Builder setButtonIcon(@Nullable DisplayDrawable buttonIcon);
+
+        public abstract Builder setButtonTitle(@Nullable DisplayString buttonTitle);
+
+        public abstract Builder setSkipToIdentifier(@Nullable String skipToIdentifier);
+    }
+
+    public static Builder builder() {
+        return new AutoValue_SkipToActionViewBase.Builder();
+    }
+
+    public static SkipToActionViewBase fromSkipToStepAction(SkipToAction skipToStepAction) {
+        // TODO rkolmos 06/07/2018 add the icon to this method.
+        return SkipToActionViewBase.builder()
+                .setButtonTitle(DisplayString.create(null, skipToStepAction.getButtonTitle()))
+                .setSkipToIdentifier(skipToStepAction.getSkipToIdentifier())
+                .build();
+    }
 }

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/model/implementations/ActiveUIStepViewBase.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/model/implementations/ActiveUIStepViewBase.java
@@ -68,13 +68,13 @@ public class ActiveUIStepViewBase extends UIStepViewBase implements ActiveUIStep
         // round off any extra precision.
         Double millis = (activeUIStep.getDuration() != null ? activeUIStep.getDuration() : 0D) * 1000;
         Duration duration = Duration.ofMillis(millis.longValue());
-        return new ActiveUIStepViewBase(uiStepView.getIdentifier(), uiStepView.getNavDirection(),
+        return new ActiveUIStepViewBase(uiStepView.getIdentifier(),
                 uiStepView.getActions(), uiStepView.getTitle(), uiStepView.getText(), uiStepView.getDetail(),
                 uiStepView.getFootnote(), uiStepView.getColorTheme(), uiStepView.getImageTheme(), duration,
                 activeUIStep.isBackgroundAudioRequired());
     }
 
-    public ActiveUIStepViewBase(@NonNull final String identifier, final int navDirection,
+    public ActiveUIStepViewBase(@NonNull final String identifier,
             @NonNull final ImmutableMap<String, ActionView> actions,
             @Nullable final DisplayString title,
             @Nullable final DisplayString text,
@@ -83,7 +83,7 @@ public class ActiveUIStepViewBase extends UIStepViewBase implements ActiveUIStep
             @Nullable final ColorThemeView colorTheme,
             @Nullable final ImageThemeView imageTheme, @NonNull final Duration duration,
             final boolean isBackgroundAudioRequired) {
-        super(identifier, navDirection, actions, title, text, detail, footnote, colorTheme, imageTheme);
+        super(identifier, actions, title, text, detail, footnote, colorTheme, imageTheme);
         this.duration = duration;
         this.isBackgroundAudioRequired = isBackgroundAudioRequired;
     }

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/model/implementations/CountdownStepViewBase.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/model/implementations/CountdownStepViewBase.java
@@ -19,13 +19,13 @@ import org.threeten.bp.Duration;
 public class CountdownStepViewBase extends ActiveUIStepViewBase implements CountdownStepView {
     public static final String TYPE = StepType.COUNTDOWN;
 
-    public CountdownStepViewBase(@NonNull String identifier, int navDirection,
+    public CountdownStepViewBase(@NonNull String identifier,
                                  @NonNull ImmutableMap<String, ActionView> actions,
                                  @Nullable DisplayString title, @Nullable DisplayString text,
                                  @Nullable DisplayString detail, @Nullable DisplayString footnote,
                                  @Nullable ColorThemeView colorTheme, @Nullable ImageThemeView imageTheme,
                                  @NonNull Duration duration, boolean isBackgroundAudioRequired) {
-        super(identifier, navDirection, actions, title, text, detail, footnote, colorTheme, imageTheme, duration, isBackgroundAudioRequired);
+        super(identifier, actions, title, text, detail, footnote, colorTheme, imageTheme, duration, isBackgroundAudioRequired);
     }
 
     public static CountdownStepViewBase fromCountdownStep(Step step, DrawableMapper mapper) {
@@ -34,7 +34,7 @@ public class CountdownStepViewBase extends ActiveUIStepViewBase implements Count
         }
 
         ActiveUIStepViewBase activeStep = ActiveUIStepViewBase.fromActiveUIStep(step, mapper);
-        return new CountdownStepViewBase(activeStep.getIdentifier(), activeStep.getNavDirection(),
+        return new CountdownStepViewBase(activeStep.getIdentifier(),
                 activeStep.getActions(), activeStep.getTitle(), activeStep.getText(),
                 activeStep.getDetail(), activeStep.getFootnote(), activeStep.getColorTheme(),
                 activeStep.getImageTheme(), activeStep.getDuration(), activeStep.isBackgroundAudioRequired());

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/model/implementations/FormUIStepViewBase.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/model/implementations/FormUIStepViewBase.java
@@ -71,13 +71,12 @@ public class FormUIStepViewBase extends UIStepViewBase implements FormUIStepView
             inputFields.add(InputFieldViewBase.fromInputField(field, mapper));
         }
 
-        return new FormUIStepViewBase(uiStepView.getIdentifier(), uiStepView.getNavDirection(),
+        return new FormUIStepViewBase(uiStepView.getIdentifier(),
                 uiStepView.getActions(), uiStepView.getTitle(), uiStepView.getText(), uiStepView.getDetail(),
                 uiStepView.getFootnote(), uiStepView.getColorTheme(), uiStepView.getImageTheme(), inputFields);
     }
 
     public FormUIStepViewBase(@NonNull final String identifier,
-            @NavDirection final int navDirection,
             @NonNull final ImmutableMap<String, ActionView> actions,
             @Nullable final DisplayString title,
             @Nullable final DisplayString text,
@@ -86,7 +85,7 @@ public class FormUIStepViewBase extends UIStepViewBase implements FormUIStepView
             @Nullable final ColorThemeView colorTheme,
             @Nullable final ImageThemeView imageTheme,
             final List<InputFieldView> inputFields) {
-        super(identifier, navDirection, actions, title, text, detail, footnote, colorTheme, imageTheme);
+        super(identifier, actions, title, text, detail, footnote, colorTheme, imageTheme);
         this.inputFields = inputFields;
     }
 

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/model/implementations/UIStepViewBase.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/model/implementations/UIStepViewBase.java
@@ -45,7 +45,7 @@ import org.sagebionetworks.research.domain.step.interfaces.Step;
 import org.sagebionetworks.research.domain.step.interfaces.ThemedUIStep;
 import org.sagebionetworks.research.domain.step.ui.action.Action;
 import org.sagebionetworks.research.domain.step.ui.action.ReminderAction;
-import org.sagebionetworks.research.domain.step.ui.action.SkipToStepAction;
+import org.sagebionetworks.research.domain.step.ui.action.SkipToAction;
 import org.sagebionetworks.research.presentation.model.action.ActionType;
 import org.sagebionetworks.research.presentation.DisplayString;
 import org.sagebionetworks.research.presentation.mapper.DrawableMapper;
@@ -54,7 +54,7 @@ import org.sagebionetworks.research.presentation.model.ImageThemeView;
 import org.sagebionetworks.research.presentation.model.action.ActionView;
 import org.sagebionetworks.research.presentation.model.action.ActionViewBase;
 import org.sagebionetworks.research.presentation.model.action.ReminderActionViewBase;
-import org.sagebionetworks.research.presentation.model.action.SkipToStepActionViewBase;
+import org.sagebionetworks.research.presentation.model.action.SkipToActionViewBase;
 import org.sagebionetworks.research.presentation.model.interfaces.UIStepView;
 
 import java.util.HashMap;
@@ -81,9 +81,6 @@ public class UIStepViewBase implements UIStepView {
 
     @Nullable
     private final ImageThemeView imageTheme;
-
-    @NavDirection
-    private final int navDirection;
 
     @Nullable
     private final DisplayString text;
@@ -113,9 +110,7 @@ public class UIStepViewBase implements UIStepView {
         DisplayString footnote = DisplayString.create(null, uiStep.getFootnote());
         ColorThemeView colorTheme = ColorThemeView.fromColorTheme(uiStep.getColorTheme());
         ImageThemeView imageTheme = ImageThemeView.fromImageTheme(uiStep.getImageTheme(), mapper);
-        // TODO: rkolmos 05/30/2018 for now the nav direction is always left.
-        return new UIStepViewBase(identifier, NavDirection.SHIFT_LEFT, actions, title, text, detail, footnote,
-                colorTheme, imageTheme);
+        return new UIStepViewBase(identifier, actions, title, text, detail, footnote, colorTheme, imageTheme);
     }
 
     /**
@@ -139,13 +134,12 @@ public class UIStepViewBase implements UIStepView {
      *         The imageTheme the UIStepViewBase should use, with resources fully resolved.
      */
     public UIStepViewBase(@NonNull final String identifier,
-            final int navDirection, @NonNull final ImmutableMap<String, ActionView> actions,
+            @NonNull final ImmutableMap<String, ActionView> actions,
             @Nullable final DisplayString title,
             @Nullable final DisplayString text, @Nullable final DisplayString detail,
             @Nullable final DisplayString footnote, @Nullable final ColorThemeView colorTheme,
             @Nullable final ImageThemeView imageTheme) {
         this.identifier = identifier;
-        this.navDirection = navDirection;
         this.actions = actions;
         this.title = title;
         this.text = text;
@@ -157,7 +151,6 @@ public class UIStepViewBase implements UIStepView {
 
     protected UIStepViewBase(Parcel in) {
         this.identifier = in.readString();
-        this.navDirection = in.readInt();
         this.actions = (ImmutableMap<String, ActionView>) in.readSerializable();
         this.title = in.readParcelable(DisplayString.class.getClassLoader());
         this.text = in.readParcelable(DisplayString.class.getClassLoader());
@@ -229,11 +222,6 @@ public class UIStepViewBase implements UIStepView {
     }
 
     @Override
-    public int getNavDirection() {
-        return navDirection;
-    }
-
-    @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("actions", actions)
@@ -242,7 +230,6 @@ public class UIStepViewBase implements UIStepView {
                 .add("footnote", footnote)
                 .add("identifier", identifier)
                 .add("imageTheme", imageTheme)
-                .add("navDirection", navDirection)
                 .add("text", text)
                 .add("title", title)
                 .toString();
@@ -257,8 +244,7 @@ public class UIStepViewBase implements UIStepView {
             return false;
         }
         final UIStepViewBase that = (UIStepViewBase) o;
-        return navDirection == that.navDirection &&
-                Objects.equal(actions, that.actions) &&
+        return Objects.equal(actions, that.actions) &&
                 Objects.equal(colorTheme, that.colorTheme) &&
                 Objects.equal(detail, that.detail) &&
                 Objects.equal(footnote, that.footnote) &&
@@ -271,7 +257,7 @@ public class UIStepViewBase implements UIStepView {
     @Override
     public int hashCode() {
         return Objects
-                .hashCode(actions, colorTheme, detail, footnote, identifier, imageTheme, navDirection, text, title);
+                .hashCode(actions, colorTheme, detail, footnote, identifier, imageTheme, text, title);
     }
 
     protected static Map<String, ActionView> getActionsFrom(Map<String, Action> actions) {
@@ -281,8 +267,8 @@ public class UIStepViewBase implements UIStepView {
             Action action = entry.getValue();
             if (action instanceof ReminderAction) {
                 returnValue.put(key, ReminderActionViewBase.fromReminderAction((ReminderAction) action));
-            } else if (action instanceof SkipToStepAction) {
-                returnValue.put(key, SkipToStepActionViewBase.fromSkipToStepAction((SkipToStepAction) action));
+            } else if (action instanceof SkipToAction) {
+                returnValue.put(key, SkipToActionViewBase.fromSkipToStepAction((SkipToAction) action));
             } else {
                 returnValue.put(key, ActionViewBase.fromAction(action));
             }

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/model/interfaces/StepView.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/model/interfaces/StepView.java
@@ -32,31 +32,17 @@
 
 package org.sagebionetworks.research.presentation.model.interfaces;
 
-import static java.lang.annotation.RetentionPolicy.SOURCE;
-
-import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 
 import java.io.Serializable;
-import java.lang.annotation.Retention;
 
 /**
  * //TODO: make parcelable @liujoshua 2018/08/30 Map a {@link org.sagebionetworks.research.domain.step.interfaces.Step}
  * to a {@link StepView} when data is moving from the Domain layer to this layer.
  */
 public interface StepView extends Serializable {
-    @Retention(SOURCE)
-    @IntDef({NavDirection.SHIFT_LEFT, NavDirection.SHIFT_RIGHT})
-    @interface NavDirection {
-        int SHIFT_LEFT = 1;
-        int SHIFT_RIGHT = -1;
-    }
-
     @NonNull
     String getIdentifier();
-
-    @NavDirection
-    int getNavDirection();
 
     @NonNull
     String getType();

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/perform_task/StepNavigationViewModel.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/perform_task/StepNavigationViewModel.java
@@ -66,7 +66,7 @@ public class StepNavigationViewModel {
         this.trLiveData=taskResultLiveData;
 
         forwardStepLiveData = Transformations.switchMap(taskResultLiveData,
-                tr -> Transformations.map(currentStepLiveData, s -> stepNavigator.getNextStep(s, tr)));
+                tr -> Transformations.map(currentStepLiveData, s -> stepNavigator.getNextStep(s, tr).getStep()));
         hasForwardStepLiveData = Transformations.map(forwardStepLiveData, n -> (n != null));
 
         backwardStepLiveData = Transformations.switchMap(taskResultLiveData,

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/RestartableRecorderConfiguration.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/RestartableRecorderConfiguration.java
@@ -30,38 +30,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.sagebionetworks.research.presentation.model.action;
+package org.sagebionetworks.research.presentation.recorder;
 
-import com.google.auto.value.AutoValue;
-
-import org.sagebionetworks.research.domain.step.ui.action.SkipToStepAction;
-import org.sagebionetworks.research.presentation.DisplayDrawable;
-import org.sagebionetworks.research.presentation.DisplayString;
-
-import javax.annotation.Nullable;
-
-@AutoValue
-public abstract class SkipToStepActionViewBase implements SkipToStepActionView {
-    @AutoValue.Builder
-    public abstract static class Builder {
-        public abstract SkipToStepActionViewBase build();
-
-        public abstract Builder setButtonIcon(@Nullable DisplayDrawable buttonIcon);
-
-        public abstract Builder setButtonTitle(@Nullable DisplayString buttonTitle);
-
-        public abstract Builder setSkipToStepIdentifier(@Nullable String skipToStepIdentifier);
-    }
-
-    public static Builder builder() {
-        return new AutoValue_SkipToStepActionViewBase.Builder();
-    }
-
-    public static SkipToStepActionViewBase fromSkipToStepAction(SkipToStepAction skipToStepAction) {
-        // TODO rkolmos 06/07/2018 add the icon to this method.
-        return SkipToStepActionViewBase.builder()
-                .setButtonTitle(DisplayString.create(null, skipToStepAction.getButtonTitle()))
-                .setSkipToStepIdentifier(skipToStepAction.getSkipToStepIdentifier())
-                .build();
-    }
+/**
+ * Extends `RecorderConfiguration` for a recorder that might be restarted.
+ */
+public interface RestartableRecorderConfiguration extends RecorderConfigPresentation {
+    /**
+     * @return if the file used in a previous run of a recording be deleted?
+     */
+    boolean getShouldDeletePrevious();
 }

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/reactive/ReactiveFileResultRecorder.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/reactive/ReactiveFileResultRecorder.java
@@ -116,7 +116,13 @@ public class ReactiveFileResultRecorder<E> extends ReactiveRecorder<E, FileResul
 
         try {
             reactiveDataSubscription = subscription;
+
+            // Creating a new PrintSteam object here will overwrite any
+            // file that already exists at this location
+            // If ever we want to allow for appending to a file,
+            // call new PrintStream(new FileOutputStream(outputFile, true));
             outputStream = new PrintStream(this.outputFile);
+
             outputStream.print(this.start);
         } catch (Throwable t) {
             onReactiveDataError(t);

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/sensor/SensorRecorderConfigPresentationImpl.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/sensor/SensorRecorderConfigPresentationImpl.java
@@ -56,12 +56,18 @@ public abstract class SensorRecorderConfigPresentationImpl implements SensorReco
 
         public abstract Builder setStopStepIdentifier(@Nullable String stopStepIdentifier);
 
+        public abstract Builder setShouldDeletePrevious(boolean shouldDeletePrevious);
+
         public abstract Builder setType(@NonNull String type);
     }
 
     public static Builder builder() {
-        return new AutoValue_SensorRecorderConfigPresentationImpl.Builder();
+        return new AutoValue_SensorRecorderConfigPresentationImpl.Builder()
+                .setShouldDeletePrevious(true);
     }
+
+    @Override
+    public abstract boolean getShouldDeletePrevious();
 
     @Override
     @NonNull

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/service/RecorderManager.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/service/RecorderManager.java
@@ -48,12 +48,13 @@ import org.sagebionetworks.research.domain.async.RecorderConfiguration;
 import org.sagebionetworks.research.domain.result.interfaces.Result;
 import org.sagebionetworks.research.domain.step.interfaces.Step;
 import org.sagebionetworks.research.domain.task.Task;
+import org.sagebionetworks.research.domain.task.navigation.NavDirection;
 import org.sagebionetworks.research.presentation.inject.RecorderConfigPresentationFactory;
-import org.sagebionetworks.research.presentation.model.interfaces.StepView.NavDirection;
 import org.sagebionetworks.research.presentation.perform_task.TaskResultManager;
 import org.sagebionetworks.research.presentation.perform_task.TaskResultManager.TaskResultManagerConnection;
 import org.sagebionetworks.research.presentation.recorder.Recorder;
 import org.sagebionetworks.research.presentation.recorder.RecorderConfigPresentation;
+import org.sagebionetworks.research.presentation.recorder.RestartableRecorderConfiguration;
 import org.sagebionetworks.research.presentation.recorder.service.RecorderService.RecorderBinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -167,23 +168,38 @@ public class RecorderManager implements ServiceConnection {
         }
 
         Set<RecorderConfigPresentation> shouldStart = new HashSet<>();
-        Set<RecorderConfigPresentation> shouldStop = new HashSet<>();
         Set<RecorderConfigPresentation> shouldCancel = new HashSet<>();
+        Set<RecorderConfigPresentation> shouldStop = new HashSet<>();
+
+        // There are a few scenarios I can think of that
 
         for (RecorderConfigPresentation config : this.recorderConfigs) {
             String startStepIdentifier = config.getStartStepIdentifier();
             String stopStepIdentifier = config.getStopStepIdentifier();
-            if (navDirection == NavDirection.SHIFT_LEFT) {
-                if (nextStep != null && startStepIdentifier.equals(nextStep.getIdentifier())) {
-                    // The recorder should be started since we are navigating to it's start step.
-                    shouldStart.add(config);
-                }
-                if (previousStep != null && stopStepIdentifier.equals(previousStep.getIdentifier())) {
-                    // The recorder should be stopped. Since it's stop step identifier has just ended.
+
+            // No matter the navigation direction, if we are leaving the stop step, we should stop the recorder
+            if (previousStep != null && stopStepIdentifier.equals(previousStep.getIdentifier())) {
+                LOGGER.info("previousStep is stopStep, stopping recorder config " + config.getIdentifier());
+                // The recorder should be stopped. Since it's stop step identifier has just ended.
+                shouldStop.add(config);
+            }
+
+            if (nextStep != null && startStepIdentifier != null &&
+                    startStepIdentifier.equals(nextStep.getIdentifier())) {
+                LOGGER.info("nextStep is startStep, starting recorder config " + config.getIdentifier());
+                // The recorder should be started since we are navigating to it's start step.
+                shouldStart.add(config);
+            }
+
+            // Did user navigate backwards?
+            if (navDirection == NavDirection.SHIFT_RIGHT) {
+                // There may be more scenarios we encounter as we add more complex navigation for recorders;
+                // however, for now let's make sure that if we navigate backwards from the start step,
+                // the recorder knows it should be stopped, because the previous step started it.
+                if (previousStep != null && startStepIdentifier != null &&
+                        startStepIdentifier.equals(previousStep.getIdentifier())) {
                     shouldStop.add(config);
                 }
-            } else if (navDirection == NavDirection.SHIFT_RIGHT) {
-                // TODO: rkolmos 06/14/2018 Figure out what should happen to recorder when the user goes back.
             }
         }
 
@@ -194,10 +210,21 @@ public class RecorderManager implements ServiceConnection {
         if (this.bound) {
             Map<String, Recorder<? extends Result>> activeRecorders = this.getActiveRecorders();
             for (RecorderConfigPresentation config : Sets.difference(shouldStart, startAndStopOrCancel)) {
-                // only wait for results of recorders which were started
-                taskResultManagerConnectionSingle.blockingGet()
-                        .addAsyncActionResult(activeRecorders.get(config.getIdentifier()).getResult());
-                this.service.startRecorder(this.taskRunUUID, config.getIdentifier());
+                Recorder activeRecorder = activeRecorders.get(config.getIdentifier());
+                // This is important to call before creating the result because this may
+                // re-create the recorder to prep for a proper recorder restart
+                activeRecorder = validateRecorderStateBeforeStart(activeRecorder, config);
+
+                if (activeRecorder != null) {
+                    // Only wait for results of recorders which were started
+                    taskResultManagerConnectionSingle.blockingGet()
+                            .addAsyncActionResult(activeRecorder.getResult());
+                    this.service.startRecorder(this.taskRunUUID, config.getIdentifier());
+                    LOGGER.info("Starting recorder " + config.getIdentifier());
+                } else {
+                    // Recorder data will not be collected and uploaded here, but at least the app will not crash
+                    LOGGER.error("Failed to restart recorder " + config.getIdentifier());
+                }
             }
 
             for (RecorderConfigPresentation config : Sets.difference(shouldStop, startAndStopOrCancel)) {
@@ -205,6 +232,7 @@ public class RecorderManager implements ServiceConnection {
                 if (activeRecorders.containsKey(identifier)) {
                     if (activeRecorders.get(identifier).isRecording()) {
                         this.service.stopRecorder(this.taskRunUUID, identifier);
+                        LOGGER.info("Stopping recorder " + config.getIdentifier());
                     }
                 }
             }
@@ -213,6 +241,7 @@ public class RecorderManager implements ServiceConnection {
                 String identifier = config.getIdentifier();
                 if (activeRecorders.containsKey(identifier)) {
                     if (activeRecorders.get(identifier).isRecording()) {
+                        LOGGER.info("Canceling recorder " + config.getIdentifier());
                         this.service.cancelRecorder(this.taskRunUUID, identifier);
                     }
                 }
@@ -221,6 +250,45 @@ public class RecorderManager implements ServiceConnection {
             LOGGER.warn("OnStepTransition was called but RecorderService was unbound.");
             // TODO: rkolmos 06/20/2018 handle the service being unbound
         }
+    }
+
+    /**
+     * Validate the state of the recorder so we know it is ok to start it without having any restart complications.
+     * @param recorder we will be starting
+     * @param config the config of the recorder that will be starting
+     */
+    @Nullable
+    private Recorder validateRecorderStateBeforeStart(
+            @Nullable Recorder<? extends Result> recorder, @NonNull RecorderConfigPresentation config) {
+
+        if (recorder == null) {
+            // A null active recorder here means that the recorder has already run and been completed
+            if (config instanceof RestartableRecorderConfiguration) {
+                RestartableRecorderConfiguration restartableConfig = (RestartableRecorderConfiguration)config;
+                if (!restartableConfig.getShouldDeletePrevious()) {
+                    // To support Recorder restart with appending data functionality,
+                    // We will need to somehow pass in a flag to ReactiveFileResultRecorder to
+                    // signal it to open the outputFile for appending.
+                    throw new IllegalStateException("RecorderManager cannot restart this recorder " +
+                            "because getShouldDeletePrevious returns false and recorder appending is not supported yet.");
+                }
+
+                // At this point, we know that the dev has configured the recorder properly to restart
+                // and they are ok with the recorder file being replaced by the new one.
+                // In this case, let's re-create the recorder to allow it to restart appropriately.
+                try {
+                    LOGGER.info("Recreating restartable recorder " + config.getIdentifier());
+                    recorder = this.service.createRecorder(this.taskRunUUID, config);
+                } catch (IOException e) {
+                    LOGGER.error("Encountered IOException while initializing recorder " + config.getIdentifier(), e);
+                }
+            } else {
+                throw new IllegalStateException("RecorderManager cannot restart a recorder unless it\'s " +
+                        "configured as a RestartableRecorderConfiguration and specifies " +
+                        "it should delete the previous data file when restarting");
+            }
+        }
+        return recorder;
     }
 
     private Set<RecorderConfigPresentation> getRecorderConfigs() {

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/service/RecorderManager.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/service/RecorderManager.java
@@ -210,7 +210,7 @@ public class RecorderManager implements ServiceConnection {
         if (this.bound) {
             Map<String, Recorder<? extends Result>> activeRecorders = this.getActiveRecorders();
             for (RecorderConfigPresentation config : Sets.difference(shouldStart, startAndStopOrCancel)) {
-                Recorder activeRecorder = activeRecorders.get(config.getIdentifier());
+                Recorder<? extends Result> activeRecorder = activeRecorders.get(config.getIdentifier());
                 // This is important to call before creating the result because this may
                 // re-create the recorder to prep for a proper recorder restart
                 activeRecorder = validateRecorderStateBeforeStart(activeRecorder, config);
@@ -258,7 +258,7 @@ public class RecorderManager implements ServiceConnection {
      * @param config the config of the recorder that will be starting
      */
     @Nullable
-    private Recorder validateRecorderStateBeforeStart(
+    private Recorder<? extends Result> validateRecorderStateBeforeStart(
             @Nullable Recorder<? extends Result> recorder, @NonNull RecorderConfigPresentation config) {
 
         if (recorder == null) {

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/service/RecorderService.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/service/RecorderService.java
@@ -259,9 +259,7 @@ public class RecorderService extends DaggerService {
      *         The identifier of the recorder to start.
      */
     public void startRecorder(@NonNull UUID taskIdentifier, @NonNull String recorderIdentifier) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Starting recorder: " + recorderIdentifier);
-        }
+        LOGGER.info("Starting recorder: " + recorderIdentifier);
 
         Recorder recorder = this.getRecorder(taskIdentifier, recorderIdentifier);
         if (recorder == null) {
@@ -281,9 +279,7 @@ public class RecorderService extends DaggerService {
      *         The identifier of the recorder to stop.
      */
     public void stopRecorder(@NonNull UUID taskIdentifier, @NonNull String recorderIdentifier) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Stopping recorder: " + recorderIdentifier);
-        }
+        LOGGER.info("Stopping recorder: " + recorderIdentifier);
 
         Recorder recorder = this.getRecorder(taskIdentifier, recorderIdentifier);
         if (recorder == null) {
@@ -292,7 +288,6 @@ public class RecorderService extends DaggerService {
         }
 
         recorder.stop();
-        // Remove the recorder for the mapping of active recorders
         this.recorderMapping.get(taskIdentifier).remove(recorderIdentifier);
     }
 

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/util/TaskOutputFileUtil.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/recorder/util/TaskOutputFileUtil.java
@@ -55,7 +55,8 @@ public final class TaskOutputFileUtil {
         String outputFilename = taskRunUUID.toString() + "/" + filename;
 
         File outputFile = new File(path, outputFilename);
-        if (!outputFile.isFile()) {
+
+        if (!outputFile.isFile() && !outputFile.exists()) {
             outputFile.getParentFile().mkdirs();
             outputFile.createNewFile();
         }

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/show_step/show_step_view_models/ShowActiveUIStepViewModel.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/show_step/show_step_view_models/ShowActiveUIStepViewModel.java
@@ -35,7 +35,10 @@ package org.sagebionetworks.research.presentation.show_step.show_step_view_model
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.LiveDataReactiveStreams;
 import android.arch.lifecycle.MutableLiveData;
+import android.arch.lifecycle.Observer;
+import android.support.annotation.NonNull;
 
+import org.jetbrains.annotations.Nullable;
 import org.sagebionetworks.research.presentation.model.interfaces.ActiveUIStepView;
 import org.sagebionetworks.research.presentation.perform_task.PerformTaskViewModel;
 import org.threeten.bp.Instant;
@@ -49,19 +52,72 @@ public class ShowActiveUIStepViewModel<S extends ActiveUIStepView> extends ShowU
     protected LiveData<Long> tempLiveData;
     protected MutableLiveData<Long> countdown;
 
+    protected @Nullable Observer<Long> countDownObserver;
+    protected @NonNull Long currentDuration = 0L;
+    protected @NonNull Long currentStartingValue = 0L;
+
+    public boolean isCountdownStarted() {
+        return countDownObserver != null;
+    }
+
     public ShowActiveUIStepViewModel(final PerformTaskViewModel performTaskViewModel, final S stepView) {
         super(performTaskViewModel, stepView);
         this.countdown = new MutableLiveData<>();
     }
 
+    /**
+     * This function starts the countdown from a value equal to the step view's provided duration,
+     * and counts down at second intervals.
+     * To get a countdown update every second, observe countdown LiveData.
+     */
     public void startCountdown() {
-            long duration = this.stepView.getDuration().getSeconds();
-            this.tempLiveData = LiveDataReactiveStreams.fromPublisher(
-                    new FlowableFromObservable<>(
-                            Observable.<Long>intervalRange(0, duration + 1,
-                                    0, 1, TimeUnit.SECONDS)
-                                    .map(i -> duration - i)));
-            this.tempLiveData.observeForever(this.countdown::setValue);
+        removeAnyPreviousObservers();
+        currentStartingValue = 0L;
+        currentDuration = this.stepView.getDuration().getSeconds();
+        resumeCountdown();
+    }
+
+    /**
+     * Called every second through the FlowableFromObservable.
+     * @param countDown current value of the count down
+     */
+    protected void updateCountdown(Long countDown) {
+        currentStartingValue = currentDuration - countDown;
+        this.countdown.setValue(countDown);
+    }
+
+    /**
+     * This function pauses the countdown at its current countdown value.
+     */
+    public void pauseCountdown() {
+        removeAnyPreviousObservers();
+    }
+
+    /**
+     * This resumes the countdown from whatever its countdown value was when pauseCountdown() was called.
+     * If pauseCountdown() was never called, nothing is done.
+     */
+    public void resumeCountdown() {
+        if (isCountdownStarted()) {
+            return;  // Guard against pauseCountdown() never being called.
+        }
+        this.tempLiveData = LiveDataReactiveStreams.fromPublisher(
+                new FlowableFromObservable<>(
+                        Observable.<Long>intervalRange(currentStartingValue, currentDuration + 1,
+                                0, 1, TimeUnit.SECONDS)
+                                .map(i -> currentDuration - i)));
+        countDownObserver = this::updateCountdown;
+        this.tempLiveData.observeForever(countDownObserver);
+    }
+
+    /**
+     * This stops the countdown by removing the countdown observer.
+     */
+    protected void removeAnyPreviousObservers() {
+        if (countDownObserver != null) {
+            this.tempLiveData.removeObserver(countDownObserver);
+            countDownObserver = null;
+        }
     }
 
     public LiveData<Long> getCountdown() {

--- a/presentation/src/main/java/org/sagebionetworks/research/presentation/show_step/show_step_view_models/ShowUIStepViewModel.java
+++ b/presentation/src/main/java/org/sagebionetworks/research/presentation/show_step/show_step_view_models/ShowUIStepViewModel.java
@@ -57,6 +57,12 @@ public class ShowUIStepViewModel<S extends UIStepView> extends ShowStepViewModel
     protected final S stepView;
 
     private final Instant startTime;
+    /**
+     * @return the instant when the step view started
+     */
+    public Instant getStartTime() {
+        return startTime;
+    }
 
     public ShowUIStepViewModel(PerformTaskViewModel performTaskViewModel, S stepView) {
         this.performTaskViewModel = performTaskViewModel;

--- a/presentation/src/test/java/org/sagebionetworks/research/presentation/perform_task/StepNavigationViewModelTest.java
+++ b/presentation/src/test/java/org/sagebionetworks/research/presentation/perform_task/StepNavigationViewModelTest.java
@@ -102,7 +102,8 @@ public class StepNavigationViewModelTest {
         verify(previousStepObs, atLeastOnce()).onChanged(null);
         verify(nextStepObs, atLeastOnce()).onChanged(nextStep2);
 
-        when(stepNavigator.getNextStep(eq(nextStep2), eq(taskResult))).thenReturn(null);
+        when(stepNavigator.getNextStep(eq(nextStep2), eq(taskResult)))
+                .thenReturn(new StepAndNavDirection(null, NavDirection.SHIFT_LEFT));
         when(stepNavigator.getPreviousStep(eq(nextStep2), eq(taskResult))).thenReturn(nextStep);
 
         stepNavigationViewModel.goForward();
@@ -121,7 +122,8 @@ public class StepNavigationViewModelTest {
         reset(stepNavigator);
 
         TaskResult taskResult2 = mock(TaskResult.class);
-        when(stepNavigator.getNextStep(eq(nextStep), eq(taskResult2))).thenReturn(null);
+        when(stepNavigator.getNextStep(eq(nextStep), eq(taskResult2)))
+                .thenReturn(new StepAndNavDirection(null, NavDirection.SHIFT_LEFT));
         when(stepNavigator.getPreviousStep(eq(nextStep), eq(taskResult2))).thenReturn(nextStep2);
 
         taskResultMutableLiveData.setValue(taskResult2);

--- a/presentation/src/test/java/org/sagebionetworks/research/presentation/perform_task/StepNavigationViewModelTest.java
+++ b/presentation/src/test/java/org/sagebionetworks/research/presentation/perform_task/StepNavigationViewModelTest.java
@@ -51,6 +51,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.sagebionetworks.research.domain.result.interfaces.TaskResult;
 import org.sagebionetworks.research.domain.step.interfaces.Step;
+import org.sagebionetworks.research.domain.task.navigation.NavDirection;
+import org.sagebionetworks.research.domain.task.navigation.StepAndNavDirection;
 import org.sagebionetworks.research.domain.task.navigation.StepNavigator;
 
 public class StepNavigationViewModelTest {
@@ -77,7 +79,8 @@ public class StepNavigationViewModelTest {
 
         TaskResult taskResult = mock(TaskResult.class);
 
-        when(stepNavigator.getNextStep(isNull(), eq(taskResult))).thenReturn(nextStep);
+        when(stepNavigator.getNextStep(isNull(), eq(taskResult))).thenReturn(new StepAndNavDirection(nextStep,
+                NavDirection.SHIFT_LEFT));
 
         stepNavigationViewModel.getCurrentStepLiveData().observeForever(currentStepObs);
         stepNavigationViewModel.getForwardStepLiveData().observeForever(nextStepObs);
@@ -89,7 +92,8 @@ public class StepNavigationViewModelTest {
         verify(previousStepObs, atLeastOnce()).onChanged(null);
         verify(nextStepObs, atLeastOnce()).onChanged(nextStep);
 
-        when(stepNavigator.getNextStep(eq(nextStep), eq(taskResult))).thenReturn(nextStep2);
+        when(stepNavigator.getNextStep(eq(nextStep), eq(taskResult))).thenReturn(new StepAndNavDirection(nextStep2,
+                NavDirection.SHIFT_LEFT));
         when(stepNavigator.getPreviousStep(eq(nextStep), eq(taskResult))).thenReturn(null);
 
         stepNavigationViewModel.goForward();


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/AA-355

This PR adds recorder restart functionality to the RecorderManager so that the walk and balance task can be restarted.

To align with iOS, a RestartableRecorderConfiguration was created with shouldDeletePrevious() function.  As with iOS, only overwrite is currently supported; however, I wrote in code comments how we would go about implementing an appending type recorder if the need for one was ever encountered.

With this work, I also discovered the skipToIdentifier feature wasn't working, because it was improperly named "skipToStepIdentifier".  Also, the NavigationDirection wasn't actually being properly associated with the StepView so that the screen transition reflected navigating backwards.